### PR TITLE
chore: Add better logging information when a received OCPP message ca…

### DIFF
--- a/core/src/main/kotlin/com/monta/library/ocpp/common/profile/OcppRequest.kt
+++ b/core/src/main/kotlin/com/monta/library/ocpp/common/profile/OcppRequest.kt
@@ -1,3 +1,17 @@
 package com.monta.library.ocpp.common.profile
 
-interface OcppRequest
+interface OcppRequest {
+
+    /**
+     * Return the OCPP action for the request. Used for logging, exceptions and debugging.
+     *
+     * By convention all our request classes end with "Request" suffix.
+     */
+    fun actionName(): String {
+        val className = this::class.java.simpleName
+        if (className.endsWith("Request")) {
+            return className.dropLast(7)
+        }
+        return className
+    }
+}

--- a/core/src/test/kotlin/com/monta/library/ocpp/common/profile/OcppRequestTest.kt
+++ b/core/src/test/kotlin/com/monta/library/ocpp/common/profile/OcppRequestTest.kt
@@ -1,0 +1,22 @@
+package com.monta.library.ocpp.common.profile
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class OcppRequestTest : StringSpec({
+
+    "action name for request classes following the convention of ending in 'Request" {
+        class TestRequest : OcppRequest
+        TestRequest().actionName() shouldBe "Test"
+    }
+
+    "action name for request classes that does not follow the standard conventions" {
+        class TestRequestWithSuffix : OcppRequest
+        TestRequestWithSuffix().actionName() shouldBe "TestRequestWithSuffix"
+    }
+
+    "action name for request classes with simple name" {
+        class Test : OcppRequest
+        Test().actionName() shouldBe "Test"
+    }
+})

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlinVersion=2.0.20
 javaToolChainVersion=17
-libraryVersion=1.0.3
+libraryVersion=1.0.4
 org.gradle.jvmargs=-Xmx4096m
 org.gradle.warning.mode=all

--- a/v16/src/main/kotlin/com/monta/library/ocpp/v16/core/CoreProfile.kt
+++ b/v16/src/main/kotlin/com/monta/library/ocpp/v16/core/CoreProfile.kt
@@ -45,7 +45,7 @@ class CoreClientProfile(
             is RemoteStopTransactionRequest -> listener.remoteStopTransactionRequest(ocppSessionInfo, request)
             is ResetRequest -> listener.resetRequest(ocppSessionInfo, request)
             is UnlockConnectorRequest -> listener.unlockConnectorRequest(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -168,7 +168,7 @@ class CoreServerProfile(
             is StartTransactionRequest -> listener.startTransaction(ocppSessionInfo, request)
             is StopTransactionRequest -> listener.stopTransaction(ocppSessionInfo, request)
             is StatusNotificationRequest -> listener.statusNotification(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v16/src/main/kotlin/com/monta/library/ocpp/v16/firmware/FirmwareManagementProfile.kt
+++ b/v16/src/main/kotlin/com/monta/library/ocpp/v16/firmware/FirmwareManagementProfile.kt
@@ -30,7 +30,7 @@ class FirmwareManagementServerProfile(
             )
 
             is FirmwareStatusNotificationRequest -> listener.firmwareStatusNotification(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -75,7 +75,7 @@ class FirmwareManagementClientProfile(
         return when (request) {
             is GetDiagnosticsRequest -> listener.getDiagnostics(ocppSessionInfo, request)
             is UpdateFirmwareRequest -> listener.updateFirmware(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v16/src/main/kotlin/com/monta/library/ocpp/v16/localauth/LocalListProfile.kt
+++ b/v16/src/main/kotlin/com/monta/library/ocpp/v16/localauth/LocalListProfile.kt
@@ -18,7 +18,7 @@ class LocalListServerProfile : ProfileDispatcher {
         ocppSessionInfo: OcppSession.Info,
         request: OcppRequest
     ): OcppConfirmation {
-        throw OcppCallException(MessageErrorCodeV16.NotSupported)
+        throw OcppCallException(MessageErrorCodeV16.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
     }
 
     interface Sender {
@@ -48,7 +48,7 @@ class LocalListClientProfile(
         return when (request) {
             is GetLocalListVersionRequest -> listener.getLocalListVersion(ocppSessionInfo, request)
             is SendLocalListRequest -> listener.sendLocalList(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v16/src/main/kotlin/com/monta/library/ocpp/v16/remotetrigger/TriggerMessage.kt
+++ b/v16/src/main/kotlin/com/monta/library/ocpp/v16/remotetrigger/TriggerMessage.kt
@@ -92,7 +92,7 @@ class TriggerMessageServerProfile : ProfileDispatcher {
         ocppSessionInfo: OcppSession.Info,
         request: OcppRequest
     ): OcppConfirmation {
-        throw OcppCallException(MessageErrorCodeV16.NotSupported)
+        throw OcppCallException(MessageErrorCodeV16.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
     }
 
     interface Sender {
@@ -116,7 +116,7 @@ class TriggerMessageClientProfile(
     ): OcppConfirmation {
         return when (request) {
             is TriggerMessageRequest -> listener.triggerMessage(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v16/src/main/kotlin/com/monta/library/ocpp/v16/security/SecurityProfile.kt
+++ b/v16/src/main/kotlin/com/monta/library/ocpp/v16/security/SecurityProfile.kt
@@ -45,7 +45,7 @@ class SecurityServerProfile(
                 request
             )
 
-            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -132,7 +132,7 @@ class SecurityClientProfile(
             is GetInstalledCertificateIdsRequest -> listener.getInstalledCertificateIds(ocppSessionInfo, request)
             is InstallCertificateRequest -> listener.installCertificate(ocppSessionInfo, request)
             is SignedUpdateFirmwareRequest -> listener.signedUpdateFirmware(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v16/src/main/kotlin/com/monta/library/ocpp/v16/smartcharge/SmartChargeProfile.kt
+++ b/v16/src/main/kotlin/com/monta/library/ocpp/v16/smartcharge/SmartChargeProfile.kt
@@ -20,7 +20,7 @@ class SmartChargeServerProfile : ProfileDispatcher {
         ocppSessionInfo: OcppSession.Info,
         request: OcppRequest
     ): OcppConfirmation {
-        throw OcppCallException(MessageErrorCodeV16.NotSupported)
+        throw OcppCallException(MessageErrorCodeV16.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
     }
 
     interface Sender {
@@ -56,7 +56,7 @@ class SmartChargeClientProfile(
             is ClearChargingProfileRequest -> listener.clearChargingProfile(ocppSessionInfo, request)
             is GetCompositeScheduleRequest -> listener.getCompositeSchedule(ocppSessionInfo, request)
             is SetChargingProfileRequest -> listener.setChargingProfile(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV16.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/authorization/AuthorizationBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/authorization/AuthorizationBlock.kt
@@ -14,7 +14,7 @@ class AuthorizationClientDispatcher : ProfileDispatcher {
         ocppSessionInfo: OcppSession.Info,
         request: OcppRequest
     ): OcppConfirmation {
-        throw OcppCallException(MessageErrorCodeV201.NotSupported)
+        throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
     }
 
     interface Sender {
@@ -36,7 +36,7 @@ class AuthorizationServerDispatcher(
     ): OcppConfirmation {
         return when (request) {
             is AuthorizeRequest -> listener.authorize(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/availability/AvailabilityBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/availability/AvailabilityBlock.kt
@@ -27,7 +27,7 @@ class AvailabilityClientDispatcher(
     ): OcppConfirmation {
         return when (request) {
             is ChangeAvailabilityRequest -> listener.changeAvailability(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -62,7 +62,7 @@ class AvailabilityServerDispatcher(
         return when (request) {
             is HeartbeatRequest -> listener.heartbeat(ocppSessionInfo, request)
             is StatusNotificationRequest -> listener.statusNotification(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/certificatemanagement/CertificateManagementBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/certificatemanagement/CertificateManagementBlock.kt
@@ -33,7 +33,7 @@ class CertificateManagementClientDispatcher(
             is DeleteCertificateRequest -> listener.deleteCertificate(ocppSessionInfo, request)
             is GetInstalledCertificateIdsRequest -> listener.getInstalledCertificateIds(ocppSessionInfo, request)
             is InstallCertificateRequest -> listener.installCertificate(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -87,7 +87,7 @@ class CertificateManagementServerDispatcher(
             is Get15118EVCertificateRequest -> listener.get15118EVCertificate(ocppSessionInfo, request)
             is GetCertificateStatusRequest -> listener.getCertificateStatus(ocppSessionInfo, request)
             is SignCertificateRequest -> listener.signCertificate(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/datatransfer/DataTransferBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/datatransfer/DataTransferBlock.kt
@@ -19,7 +19,7 @@ class DataTransferClientDispatcher(
     ): OcppConfirmation {
         return when (request) {
             is DataTransferRequest -> listener.dataTransfer(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -49,7 +49,7 @@ class DataTransferServerDispatcher(
     ): OcppConfirmation {
         return when (request) {
             is DataTransferRequest -> listener.dataTransfer(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/diagnostics/DiagnosticsBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/diagnostics/DiagnosticsBlock.kt
@@ -41,7 +41,7 @@ class DiagnosticsClientDispatcher(
             is SetMonitoringBaseRequest -> listener.setMonitoringBase(ocppSessionInfo, request)
             is SetMonitoringLevelRequest -> listener.setMonitoringLevel(ocppSessionInfo, request)
             is SetVariableMonitoringRequest -> listener.setVariableMonitoring(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -116,7 +116,7 @@ class DiagnosticsServerDispatcher(
             is NotifyCustomerInformationRequest -> listener.notifyCustomerInformation(ocppSessionInfo, request)
             is NotifyEventRequest -> listener.notifyEvent(ocppSessionInfo, request)
             is NotifyMonitoringReportRequest -> listener.notifyMonitoringReport(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/displaymessage/DisplayMessageBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/displaymessage/DisplayMessageBlock.kt
@@ -30,7 +30,7 @@ class DisplayMessageClientDispatcher(
             is ClearDisplayMessageRequest -> listener.clearDisplayMessage(ocppSessionInfo, request)
             is GetDisplayMessagesRequest -> listener.getDisplayMessages(ocppSessionInfo, request)
             is SetDisplayMessageRequest -> listener.setDisplayMessage(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -70,7 +70,7 @@ class DisplayMessageServerDispatcher(
     ): OcppConfirmation {
         return when (request) {
             is NotifyDisplayMessagesRequest -> listener.notifyDisplayMessages(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/firmwaremanagement/FirmwareManagementBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/firmwaremanagement/FirmwareManagementBlock.kt
@@ -31,7 +31,7 @@ class FirmwareManagementClientDispatcher(
             is PublishFirmwareRequest -> listener.publishFirmware(ocppSessionInfo, request)
             is UnpublishFirmwareRequest -> listener.unpublishFirmware(ocppSessionInfo, request)
             is UpdateFirmwareRequest -> listener.updateFirmware(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -80,7 +80,7 @@ class FirmwareManagementServerDispatcher(
                 request
             )
 
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/localauthorizationlistmanagement/LocalAuthorizationListManagementBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/localauthorizationlistmanagement/LocalAuthorizationListManagementBlock.kt
@@ -29,7 +29,7 @@ class LocalAuthorizationListManagementClientDispatcher(
             is ClearCacheRequest -> listener.clearCache(ocppSessionInfo, request)
             is GetLocalListVersionRequest -> listener.getLocalListVersion(ocppSessionInfo, request)
             is SendLocalListRequest -> listener.sendLocalList(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -59,7 +59,7 @@ class LocalAuthorizationListManagementServerDispatcher : ProfileDispatcher {
         ocppSessionInfo: OcppSession.Info,
         request: OcppRequest
     ): OcppConfirmation {
-        throw OcppCallException(MessageErrorCodeV201.NotSupported)
+        throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
     }
 
     interface Sender {

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/metervalues/MeterValuesBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/metervalues/MeterValuesBlock.kt
@@ -14,7 +14,7 @@ class MeterValuesClientDispatcher : ProfileDispatcher {
         ocppSessionInfo: OcppSession.Info,
         request: OcppRequest
     ): OcppConfirmation {
-        throw OcppCallException(MessageErrorCodeV201.NotSupported)
+        throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
     }
 
     interface Sender {
@@ -36,7 +36,7 @@ class MeterValuesServerDispatcher(
     ): OcppConfirmation {
         return when (request) {
             is MeterValuesRequest -> listener.meterValues(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/provisioning/ProvisioningBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/provisioning/ProvisioningBlock.kt
@@ -37,7 +37,7 @@ class ProvisioningClientDispatcher(
             is ResetRequest -> listener.reset(ocppSessionInfo, request)
             is SetNetworkProfileRequest -> listener.setNetworkProfile(ocppSessionInfo, request)
             is SetVariablesRequest -> listener.setVariables(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -96,7 +96,7 @@ class ProvisioningServerDispatcher(
         return when (request) {
             is BootNotificationRequest -> listener.bootNotification(ocppSessionInfo, request)
             is NotifyReportRequest -> listener.notifyReport(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/remotecontrol/RemoteControlBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/remotecontrol/RemoteControlBlock.kt
@@ -30,7 +30,7 @@ class RemoteControlClientDispatcher(
             is RequestStopTransactionRequest -> listener.requestStopTransaction(ocppSessionInfo, request)
             is TriggerMessageRequest -> listener.triggerMessage(ocppSessionInfo, request)
             is UnlockConnectorRequest -> listener.unlockConnector(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -65,7 +65,7 @@ class RemoteControlServerDispatcher : ProfileDispatcher {
         ocppSessionInfo: OcppSession.Info,
         request: OcppRequest
     ): OcppConfirmation {
-        throw OcppCallException(MessageErrorCodeV201.NotSupported)
+        throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
     }
 
     interface Sender {

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/reservation/ReservationBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/reservation/ReservationBlock.kt
@@ -28,7 +28,7 @@ class ReservationClientDispatcher(
         return when (request) {
             is CancelReservationRequest -> listener.cancelReservation(ocppSessionInfo, request)
             is ReserveNowRequest -> listener.reserveNow(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -63,7 +63,7 @@ class ReservationServerDispatcher(
     ): OcppConfirmation {
         return when (request) {
             is ReservationStatusUpdateRequest -> listener.reservationStatusUpdate(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/security/SecurityBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/security/SecurityBlock.kt
@@ -19,7 +19,7 @@ class SecurityClientDispatcher : ProfileDispatcher {
         ocppSessionInfo: OcppSession.Info,
         request: OcppRequest
     ): OcppConfirmation {
-        throw OcppCallException(MessageErrorCodeV201.NotSupported)
+        throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
     }
 
     interface Sender {
@@ -40,7 +40,7 @@ class SecurityServerDispatcher(
     ): OcppConfirmation {
         return when (request) {
             is SecurityEventNotificationRequest -> listener.securityEventNotification(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/smartcharging/SmartChargingBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/smartcharging/SmartChargingBlock.kt
@@ -36,7 +36,7 @@ class SmartChargingClientDispatcher(
             is GetChargingProfilesRequest -> listener.getChargingProfiles(ocppSessionInfo, request)
             is GetCompositeScheduleRequest -> listener.getCompositeSchedule(ocppSessionInfo, request)
             is SetChargingProfileRequest -> listener.setChargingProfile(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -101,7 +101,7 @@ class SmartChargingServerDispatcher(
             is NotifyEVChargingNeedsRequest -> listener.notifyEVChargingNeeds(ocppSessionInfo, request)
             is NotifyEVChargingScheduleRequest -> listener.notifyEVChargingSchedule(ocppSessionInfo, request)
             is ReportChargingProfilesRequest -> listener.reportChargingProfiles(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/tariffandcost/TariffAndCostBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/tariffandcost/TariffAndCostBlock.kt
@@ -19,7 +19,7 @@ class TariffAndCostClientDispatcher(
     ): OcppConfirmation {
         return when (request) {
             is CostUpdatedRequest -> listener.costUpdated(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -38,7 +38,7 @@ class TariffAndCostServerDispatcher : ProfileDispatcher {
         ocppSessionInfo: OcppSession.Info,
         request: OcppRequest
     ): OcppConfirmation {
-        throw OcppCallException(MessageErrorCodeV201.NotSupported)
+        throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
     }
 
     interface Sender {

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/transactions/TransactionsBlock.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/transactions/TransactionsBlock.kt
@@ -26,7 +26,7 @@ class TransactionsClientDispatcher(
     ): OcppConfirmation {
         return when (request) {
             is GetTransactionStatusRequest -> listener.getTransactionStatus(request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 
@@ -55,7 +55,7 @@ class TransactionsServerDispatcher(
     ): OcppConfirmation {
         return when (request) {
             is TransactionEventRequest -> listener.transactionEvent(ocppSessionInfo, request)
-            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported)
+            else -> throw OcppCallException(MessageErrorCodeV201.NotSupported, "Requested Action [${request.actionName()}] is recognized but not supported by the receiver")
         }
     }
 


### PR DESCRIPTION
…n not be handled.

* [SERVICE-OCPP-2B9](https://monta-app.sentry.io/issues/5072807193/)
* add the 'action' in the detailed error message
* only warn log on NotSupported messages (this happens when there is a firmware bug so a charge point sends us messages that only the CSMS are supposed to send) - this will remove some sentry noise
