### PR TITLE
chore: Copy default renovate config into the lib

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>monta-app/renovate-config",
+    "config:recommended",
     ":semanticCommitTypeAll(chore)"
   ],
+  "semanticCommits": "enabled",
+  "prConcurrentLimit": 2,
   "packageRules": [
     {
       "groupName": "upgrade all non-major gradle dependencies",


### PR DESCRIPTION
* referenced a private artifact which made renovate stop working
* [slack discussion](https://monta-app01.slack.com/archives/C021656U6TB/p1733761704876939)