### PR TITLE
ignore: Adding tests that shows we break if we get StatusNotification…

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,8 +12,6 @@ jobs:
   test:
     name: Test
     uses: monta-app/github-workflows/.github/workflows/pull-request.yaml@5fe725f615503876677c1cd178a53644691ee84f
-    with:
-      gradle-module: core
     secrets:
       GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
       GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   test:
     name: Test
-    uses: monta-app/github-workflows/.github/workflows/pull-request.yaml@5fe725f615503876677c1cd178a53644691ee84f
+    uses: monta-app/github-workflows/.github/workflows/pull-request.yaml@v2
     secrets:
       GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
       GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,6 +12,8 @@ jobs:
   test:
     name: Test
     uses: monta-app/github-workflows/.github/workflows/pull-request.yaml@5fe725f615503876677c1cd178a53644691ee84f
+    with:
+      gradle-module: core
     secrets:
       GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
       GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,6 @@ jobs:
     secrets:
       GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
       GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}
-      SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
   static-code-analysis:
     name: Static Code Analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   test:
     name: Test
-    uses: monta-app/github-workflows/.github/workflows/pull-request.yaml@v2
+    uses: monta-app/github-workflows/.github/workflows/pull-request.yaml@5fe725f615503876677c1cd178a53644691ee84f
     secrets:
       GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
       GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}

--- a/v16/src/test/kotlin/com/monta/library/ocpp/profiles/serialization/StatusNotificationSerializationTest.kt
+++ b/v16/src/test/kotlin/com/monta/library/ocpp/profiles/serialization/StatusNotificationSerializationTest.kt
@@ -5,6 +5,7 @@ import com.monta.library.ocpp.common.serialization.Message
 import com.monta.library.ocpp.common.serialization.MessageSerializer
 import com.monta.library.ocpp.common.serialization.ParsingResult
 import com.monta.library.ocpp.common.serialization.SerializationMode
+import com.monta.library.ocpp.v16.core.StatusNotificationRequest
 import com.monta.library.ocpp.v16.error.OcppErrorResponderV16
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -23,6 +24,34 @@ class StatusNotificationSerializationTest : StringSpec({
         ocppMessage.uniqueId shouldBe "78ee4811-a044-417e-9c70-b51c2c296bf9"
         ocppMessage.action shouldBe "StatusNotification"
         ocppMessage.payload shouldBe TestUtils.toJsonNode("{\"connectorId\":1,\"errorCode\":\"NoError\",\"status\":\"Available\"}")
+    }
+
+    "parse a valid status notification request with a timestamp" {
+        val jsonString = TestUtils.getFileAsString("status_notification/req-timestamp.json")
+        val parsingResult = messageSerializer.parse(jsonString)
+
+        parsingResult.shouldBeInstanceOf<ParsingResult.Success<Message.Request>>()
+        val ocppMessage = parsingResult.value
+        ocppMessage.shouldBeInstanceOf<Message.Request>()
+        val expected = messageSerializer.deserializePayload(ocppMessage, StatusNotificationRequest::class.java)
+        expected.shouldBeInstanceOf<ParsingResult.Success<StatusNotificationRequest>>()
+        ocppMessage.uniqueId shouldBe "2024120922534800000049"
+        ocppMessage.action shouldBe "StatusNotification"
+        ocppMessage.payload shouldBe TestUtils.toJsonNode("{\"connectorId\":1,\"status\":\"Available\",\"errorCode\":\"NoError\",\"info\":\"eCp_12V\",\"timestamp\":\"2024-12-09T22:53:49.000Z\"}")
+    }
+
+    "parse a valid status notification request with a timestamp without a timezone" {
+        val jsonString = TestUtils.getFileAsString("status_notification/req-timestamp-no-timezone.json")
+        val parsingResult = messageSerializer.parse(jsonString)
+
+        parsingResult.shouldBeInstanceOf<ParsingResult.Success<Message.Request>>()
+        val ocppMessage = parsingResult.value
+        ocppMessage.shouldBeInstanceOf<Message.Request>()
+        val expected = messageSerializer.deserializePayload(ocppMessage, StatusNotificationRequest::class.java)
+        expected.shouldBeInstanceOf<ParsingResult.Success<StatusNotificationRequest>>()
+        ocppMessage.uniqueId shouldBe "2024120922534800000049"
+        ocppMessage.action shouldBe "StatusNotification"
+        ocppMessage.payload shouldBe TestUtils.toJsonNode("{\"connectorId\":1,\"status\":\"Available\",\"errorCode\":\"NoError\",\"info\":\"eCp_12V\",\"timestamp\":\"2024-12-09T22:53:49.000\"}")
     }
 
     "parse a valid status notification response" {

--- a/v16/src/test/resources/status_notification/req-timestamp-no-timezone.json
+++ b/v16/src/test/resources/status_notification/req-timestamp-no-timezone.json
@@ -1,0 +1,7 @@
+[2, "2024120922534800000049", "StatusNotification", {
+  "connectorId": 1,
+  "status": "Available",
+  "errorCode": "NoError",
+  "info": "eCp_12V",
+  "timestamp": "2024-12-09T22:53:49.000"
+}]

--- a/v16/src/test/resources/status_notification/req-timestamp.json
+++ b/v16/src/test/resources/status_notification/req-timestamp.json
@@ -1,0 +1,7 @@
+[2, "2024120922534800000049", "StatusNotification", {
+  "connectorId": 1,
+  "status": "Available",
+  "errorCode": "NoError",
+  "info": "eCp_12V",
+  "timestamp": "2024-12-09T22:53:49.000Z"
+}]


### PR DESCRIPTION
…s with timestamps without timezone

logs -> ["Cannot deserialize value of type `java.time.ZonedDateTime`" AND "could not be parsed at index 23"](https://monta.kb.eu-west-1.aws.found.io:9243/app/r/s/Mc9wH)

only 4 charge points in the last 24 hours - all same crappy charge point
* [AE0022G1GNAC01462W](https://cpi-tool.monta.app/charge-points/AE0022G1GNAC01462W?size=25&page=0&tab=logs&log_mode=Communication&search_query=StatusNotification)
* [AE0007A1GN2C01239K](https://cpi-tool.monta.app/charge-points/AE0007A1GN2C01239K?size=25&page=0&log_mode=Communication&search_query=StatusNotification)
* [AE0022G1GNAC013931](https://cpi-tool.monta.app/charge-points/AE0022G1GNAC013931?size=25&page=0&log_mode=Communication&search_query=StatusNotification)
* [AE0022G1GNAC016844](https://cpi-tool.monta.app/charge-points/AE0022G1GNAC016844?size=25&page=0&tab=logs&log_mode=Communication&search_query=StatusNotification)

![image](https://github.com/user-attachments/assets/cd7d6d72-06a9-4651-8a7b-10f877eb49b4)

Autel maxi charger
![image](https://github.com/user-attachments/assets/9fcbe7f1-97f9-4b54-ad21-1ba99e8a754f)

Only these 4 charge points is running that version
![image](https://github.com/user-attachments/assets/500d47c3-698b-466e-8a82-b7e6fc8d267c)
