### PR TITLE
chore: Adding unittests for parsing StatusNotification messages with …

### DIFF
--- a/server/src/main/kotlin/com/monta/ocpp/MontaApplication.kt
+++ b/server/src/main/kotlin/com/monta/ocpp/MontaApplication.kt
@@ -22,7 +22,7 @@ import com.monta.library.ocpp.v201.server.OcppServerV201Builder
 import io.ktor.serialization.jackson.*
 import io.ktor.server.application.*
 import io.ktor.server.netty.*
-import io.ktor.server.plugins.callloging.*
+import io.ktor.server.plugins.calllogging.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
@@ -34,6 +34,7 @@ import java.time.Duration
 import java.time.ZonedDateTime
 import java.util.TimeZone
 import java.util.zip.Deflater
+import kotlin.time.toKotlinDuration
 
 fun main(
     args: Array<String>
@@ -59,8 +60,8 @@ fun Application.module() {
             objectmapper = MontaSerialization.getDefaultMapper()
         )
 
-        pingPeriod = Duration.ofSeconds(15)
-        timeout = Duration.ofSeconds(15)
+        pingPeriod = Duration.ofSeconds(15).toKotlinDuration()
+        timeout = Duration.ofSeconds(15).toKotlinDuration()
 
         maxFrameSize = Long.MAX_VALUE
         masking = false

--- a/v16/src/test/kotlin/com/monta/library/ocpp/profiles/serialization/StatusNotificationSerializationTest.kt
+++ b/v16/src/test/kotlin/com/monta/library/ocpp/profiles/serialization/StatusNotificationSerializationTest.kt
@@ -5,6 +5,7 @@ import com.monta.library.ocpp.common.serialization.Message
 import com.monta.library.ocpp.common.serialization.MessageSerializer
 import com.monta.library.ocpp.common.serialization.ParsingResult
 import com.monta.library.ocpp.common.serialization.SerializationMode
+import com.monta.library.ocpp.v16.core.StatusNotificationRequest
 import com.monta.library.ocpp.v16.error.OcppErrorResponderV16
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -23,6 +24,34 @@ class StatusNotificationSerializationTest : StringSpec({
         ocppMessage.uniqueId shouldBe "78ee4811-a044-417e-9c70-b51c2c296bf9"
         ocppMessage.action shouldBe "StatusNotification"
         ocppMessage.payload shouldBe TestUtils.toJsonNode("{\"connectorId\":1,\"errorCode\":\"NoError\",\"status\":\"Available\"}")
+    }
+
+    "parse a valid status notification request with a timestamp" {
+        val jsonString = TestUtils.getFileAsString("status_notification/req-timestamp.json")
+        val parsingResult = messageSerializer.parse(jsonString)
+
+        parsingResult.shouldBeInstanceOf<ParsingResult.Success<Message.Request>>()
+        val ocppMessage = parsingResult.value
+        ocppMessage.shouldBeInstanceOf<Message.Request>()
+        val expected = messageSerializer.deserializePayload(ocppMessage, StatusNotificationRequest::class.java)
+        expected.shouldBeInstanceOf<ParsingResult.Success<StatusNotificationRequest>>()
+        ocppMessage.uniqueId shouldBe "2024120922534800000049"
+        ocppMessage.action shouldBe "StatusNotification"
+        ocppMessage.payload shouldBe TestUtils.toJsonNode("{\"connectorId\":1,\"status\":\"Available\",\"errorCode\":\"NoError\",\"info\":\"eCp_12V\",\"timestamp\":\"2024-12-09T22:53:49.000Z\"}")
+    }
+
+    "parse a valid status notification request with a timestamp without a timezone should fail" {
+        val jsonString = TestUtils.getFileAsString("status_notification/req-timestamp-no-timezone.json")
+        val parsingResult = messageSerializer.parse(jsonString)
+
+        parsingResult.shouldBeInstanceOf<ParsingResult.Success<Message.Request>>()
+        val ocppMessage = parsingResult.value
+        ocppMessage.shouldBeInstanceOf<Message.Request>()
+        val expected = messageSerializer.deserializePayload(ocppMessage, StatusNotificationRequest::class.java)
+        expected.shouldBeInstanceOf<ParsingResult.Failure<StatusNotificationRequest>>()
+        ocppMessage.uniqueId shouldBe "2024120922534800000049"
+        ocppMessage.action shouldBe "StatusNotification"
+        ocppMessage.payload shouldBe TestUtils.toJsonNode("{\"connectorId\":1,\"status\":\"Available\",\"errorCode\":\"NoError\",\"info\":\"eCp_12V\",\"timestamp\":\"2024-12-09T22:53:49.000\"}")
     }
 
     "parse a valid status notification response" {

--- a/v16/src/test/kotlin/com/monta/library/ocpp/v16/extension/plugandcharge/PlugAndChargeSerializationTest.kt
+++ b/v16/src/test/kotlin/com/monta/library/ocpp/v16/extension/plugandcharge/PlugAndChargeSerializationTest.kt
@@ -23,7 +23,7 @@ class PlugAndChargeSerializationTest : StringSpec({
         val json = this.javaClass.getResourceAsStream(fileName)?.bufferedReader().use { it?.readText() }!!
         val result = messageSerializer.parse(json)
         result should beInstanceOf<ParsingResult.Success<DataTransferRequest>>()
-        val resp = (result as ParsingResult.Success<Message.Request>).value
+        val resp = (result as ParsingResult.Success<*>).value as Message.Request
         val parseResult = messageSerializer.deserializePayload(resp, DataTransferRequest::class.java)
         when (parseResult) {
             is ParsingResult.Success<DataTransferRequest> -> {
@@ -40,7 +40,7 @@ class PlugAndChargeSerializationTest : StringSpec({
         val json = this.javaClass.getResourceAsStream(fileName)?.bufferedReader().use { it?.readText() }!!
         val result = messageSerializer.parse(json)
         result should beInstanceOf<ParsingResult.Success<DataTransferConfirmation>>()
-        val resp = (result as ParsingResult.Success<Message.Response>).value
+        val resp = (result as ParsingResult.Success<*>).value as Message.Response
         val parseResult = messageSerializer.deserializePayload(resp, DataTransferConfirmation::class.java)
         when (parseResult) {
             is ParsingResult.Success<DataTransferConfirmation> -> {

--- a/v16/src/test/resources/status_notification/req-timestamp-no-timezone.json
+++ b/v16/src/test/resources/status_notification/req-timestamp-no-timezone.json
@@ -1,0 +1,7 @@
+[2, "2024120922534800000049", "StatusNotification", {
+  "connectorId": 1,
+  "status": "Available",
+  "errorCode": "NoError",
+  "info": "eCp_12V",
+  "timestamp": "2024-12-09T22:53:49.000"
+}]

--- a/v16/src/test/resources/status_notification/req-timestamp.json
+++ b/v16/src/test/resources/status_notification/req-timestamp.json
@@ -1,0 +1,7 @@
+[2, "2024120922534800000049", "StatusNotification", {
+  "connectorId": 1,
+  "status": "Available",
+  "errorCode": "NoError",
+  "info": "eCp_12V",
+  "timestamp": "2024-12-09T22:53:49.000Z"
+}]


### PR DESCRIPTION
…no timestamps

* adding tests written as part of this https://github.com/monta-app/library-ocpp/pull/10
* removing a couple of build warnings triggered by cast's in a test
* fixed ktor upgrade in the test server
