### PR TITLE
fix: Increase EXI limit to 7500 (CPISU-1276)

### DIFF
--- a/v16/src/test/kotlin/com/monta/library/ocpp/TestUtils.kt
+++ b/v16/src/test/kotlin/com/monta/library/ocpp/TestUtils.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 
 object TestUtils {
     private val objectMapper = jacksonObjectMapper()
+    const val ASYNC_TIMEOUT_MS: Long = 5000
 
     fun getFileAsString(filename: String): String {
         return requireNotNull(object {}.javaClass.classLoader.getResource(filename)).readText()

--- a/v16/src/test/kotlin/com/monta/library/ocpp/extension/plugandcharge/PlugAndChargeExtensionClientTest.kt
+++ b/v16/src/test/kotlin/com/monta/library/ocpp/extension/plugandcharge/PlugAndChargeExtensionClientTest.kt
@@ -1,5 +1,6 @@
 package com.monta.library.ocpp.extension.plugandcharge
 
+import com.monta.library.ocpp.TestUtils.ASYNC_TIMEOUT_MS
 import com.monta.library.ocpp.common.profile.OcppConfirmation
 import com.monta.library.ocpp.common.serialization.Message
 import com.monta.library.ocpp.common.serialization.MessageSerializer
@@ -53,7 +54,7 @@ class PlugAndChargeExtensionClientTest : StringSpec() {
 
     init {
         "GetInstalledCertificateIdsConfirmation can be sent" {
-            val conf = withTimeout(1000L) {
+            val conf = withTimeout(ASYNC_TIMEOUT_MS) {
                 async {
                     server.asPlugAndChargeProfile(getInstalledSession)
                         .getInstalledCertificateIds(
@@ -72,7 +73,7 @@ class PlugAndChargeExtensionClientTest : StringSpec() {
         }
 
         "CertificateSigned can be sent" {
-            val conf = withTimeout(1000L) {
+            val conf = withTimeout(ASYNC_TIMEOUT_MS) {
                 async {
                     server.asPlugAndChargeProfile(certificateSignedSession)
                         .certificateSigned(
@@ -86,7 +87,7 @@ class PlugAndChargeExtensionClientTest : StringSpec() {
         }
 
         "DeleteCertificate can be sent" {
-            val conf = withTimeout(1000L) {
+            val conf = withTimeout(ASYNC_TIMEOUT_MS) {
                 async {
                     server.asPlugAndChargeProfile(deleteCertificateSession)
                         .deleteCertificate(
@@ -105,7 +106,7 @@ class PlugAndChargeExtensionClientTest : StringSpec() {
         }
 
         "InstallCertificate can be sent" {
-            val conf = withTimeout(1000L) {
+            val conf = withTimeout(ASYNC_TIMEOUT_MS) {
                 async {
                     server.asPlugAndChargeProfile(installCertificateSession)
                         .installCertificate(

--- a/v16/src/test/kotlin/com/monta/library/ocpp/extension/plugandcharge/PlugAndChargeExtensionServerProfileTest.kt
+++ b/v16/src/test/kotlin/com/monta/library/ocpp/extension/plugandcharge/PlugAndChargeExtensionServerProfileTest.kt
@@ -1,5 +1,6 @@
 package com.monta.library.ocpp.extension.plugandcharge
 
+import com.monta.library.ocpp.TestUtils.ASYNC_TIMEOUT_MS
 import com.monta.library.ocpp.common.profile.Feature
 import com.monta.library.ocpp.common.profile.OcppConfirmation
 import com.monta.library.ocpp.common.profile.OcppRequest
@@ -70,13 +71,13 @@ class PlugAndChargeExtensionServerProfileTest : StringSpec() {
         "invalid data transfer should cause error" {
             val session = createSession()
             runBlocking {
-                withTimeout(1000L) {
+                withTimeout(ASYNC_TIMEOUT_MS) {
                     async {
                         server.receiveMessage(session, """[2,"test","DataTransfer",{}]""")
                     }.await() // let exceptions bobble up.
                 }
             }
-            val error = withTimeout(1000L) { sendErrorChannel.receive() }
+            val error = withTimeout(ASYNC_TIMEOUT_MS) { sendErrorChannel.receive() }
             error.errorCode shouldBe MessageErrorCodeV16.FormationViolation.name
         }
 
@@ -321,12 +322,12 @@ class PlugAndChargeExtensionServerProfileTest : StringSpec() {
 
     private suspend fun reqExpectConf(req: Message): DataTransferConfirmation {
         val session = createSession()
-        withTimeout(1000L) {
+        withTimeout(ASYNC_TIMEOUT_MS) {
             async {
                 server.receiveMessage(session, req)
             }.await() // let exceptions bobble up.
         }
-        val msg = withTimeout(1000L) { sendResponseChannel.receive() }
+        val msg = withTimeout(ASYNC_TIMEOUT_MS) { sendResponseChannel.receive() }
         val dtConf =
             messageSerializer.deserializePayload(msg, DataTransferConfirmation::class.java) as ParsingResult.Success
         return dtConf.value

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/certificatemanagement/Get15118EVCertificate.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/certificatemanagement/Get15118EVCertificate.kt
@@ -25,8 +25,8 @@ data class Get15118EVCertificateRequest(
         require(iso15118SchemaVersion.length <= 50) {
             "iso15118SchemaVersion length > maximum 50 - ${iso15118SchemaVersion.length}"
         }
-        require(exiRequest.length <= 5600) {
-            "exiRequest length > maximum 5600 - ${exiRequest.length}"
+        require(exiRequest.length <= 7500) {
+            "exiRequest length > maximum 7500 - ${exiRequest.length}"
         }
     }
 
@@ -45,8 +45,8 @@ data class Get15118EVCertificateResponse(
 ) : OcppConfirmation {
 
     init {
-        require(exiResponse.length <= 5600) {
-            "exiResponse length > maximum 5600 - ${exiResponse.length}"
+        require(exiResponse.length <= 7500) {
+            "exiResponse length > maximum 7500 - ${exiResponse.length}"
         }
     }
 


### PR DESCRIPTION
# Description

## What?

Increase the EXI payload limit for `Get15118EVCertificate` from 5600 to 7500 characters. 

Increased the timeout when waiting for async completion of responses during tests from 1 sec to 5 sec, due to GHA build failures. 

## Why?

Allow a 4-chain certificate chain to be included and allows vehicles to signal support for multiple OEM / MO roots when requesting Contract Certificates. 
Required by Hubject Plug&Charge: https://support.hubject.com/hc/en-us/articles/9174328536221-3-6-Requirements-for-CPMS 
> 2.2 Deviation from OCPP Message Get15118EVCertificate (processual)

## Context
As part of implementing support for Plug&Charge. This is categorized as an bug, but we have not yet run into this problem in production.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - _add further detail on which functionality would break and how to migrate_
