### PR TITLE
fix: Remove serialized message payload from timeout messages

### DIFF
--- a/core/src/main/kotlin/com/monta/library/ocpp/common/transport/OcppMessageInterpreter.kt
+++ b/core/src/main/kotlin/com/monta/library/ocpp/common/transport/OcppMessageInterpreter.kt
@@ -131,7 +131,7 @@ abstract class OcppMessageInterpreter(
             completeDeferrableRepository.getCachedDeferred(ocppSessionInfo.identity, request.uniqueId)
             throw OcppCallException(
                 errorCode = ocppErrorResponder.getInternalError(),
-                msg = "Timeout for '${feature.name}' - ${messageSerializer.toPayloadString(request)}",
+                msg = "Timeout for '${feature.name}'",
                 throwable = timeoutException
             )
         } finally {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlinVersion=2.1.20
 javaToolChainVersion=17
-libraryVersion=1.0.5
+libraryVersion=1.0.6
 org.gradle.jvmargs=-Xmx4096m
 org.gradle.warning.mode=all


### PR DESCRIPTION
* this could in some cases lead to logging of problematic data (i.e. AuthPasswords)
