### PR TITLE
fix: custom data (de)serialization [cot-339]

### DIFF
--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/firmwaremanagement/UpdateFirmware.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/blocks/firmwaremanagement/UpdateFirmware.kt
@@ -72,17 +72,6 @@ data class UpdateFirmwareResponse(
     val customData: CustomData? = null
 ) : OcppConfirmation {
 
-    data class CustomData(
-        val vendorId: String
-    ) {
-
-        init {
-            require(vendorId.length <= 255) {
-                "vendorId length > maximum 255 - ${vendorId.length}"
-            }
-        }
-    }
-
     enum class Status {
         Accepted,
         Rejected,

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/common/CustomData.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/common/CustomData.kt
@@ -4,10 +4,4 @@ class CustomData : HashMap<String, String?>() {
 
     val vendorId: String
         get() = requireNotNull(get("vendorId"))
-
-    init {
-        require(vendorId.length <= 255) {
-            "vendorId length > maximum 255 - ${vendorId.length}"
-        }
-    }
 }

--- a/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/CustomDataSerializationTest.kt
+++ b/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/CustomDataSerializationTest.kt
@@ -10,7 +10,7 @@ import com.monta.library.ocpp.v201.error.OcppErrorResponderV201
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
-class CustomDataSerializationTest: StringSpec( {
+class CustomDataSerializationTest : StringSpec({
     val messageSerializer = MessageSerializer(SerializationMode.OCPP_2, OcppErrorResponderV201)
 
     "custom data (de)serialization should work" {
@@ -21,8 +21,9 @@ class CustomDataSerializationTest: StringSpec( {
             "123",
             "Heartbeat",
             messageSerializer.toPayload(
-                HeartbeatRequest(customData = x))
+                HeartbeatRequest(customData = x)
             )
+        )
         val serialized = heartbeatRequest.toJsonString(messageSerializer)
         serialized shouldBe "[2,\"123\",\"Heartbeat\",{\"customData\":{\"vendorId\":\"testVendor\",\"testKey\":\"testValue\"}}]"
     }

--- a/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/CustomDataSerializationTest.kt
+++ b/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/CustomDataSerializationTest.kt
@@ -14,14 +14,14 @@ class CustomDataSerializationTest: StringSpec( {
     val messageSerializer = MessageSerializer(SerializationMode.OCPP_2, OcppErrorResponderV201)
 
     "custom data (de)serialization should work" {
-        val x: HashMap<String, String> = HashMap()
+        val x = CustomData()
         x["vendorId"] = "testVendor"
         x["testKey"] = "testValue"
         val heartbeatRequest = Message.Request(
             "123",
             "Heartbeat",
             messageSerializer.toPayload(
-                HeartbeatRequest(customData = x as CustomData)) // fails, can't even construct CustomData, because it validates before it has data
+                HeartbeatRequest(customData = x))
             )
         val serialized = heartbeatRequest.toJsonString(messageSerializer)
         serialized shouldBe "[2,\"123\",\"Heartbeat\",{\"customData\":{\"vendorId\":\"testVendor\",\"testKey\":\"testValue\"}}]"

--- a/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/CustomDataSerializationTest.kt
+++ b/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/CustomDataSerializationTest.kt
@@ -38,5 +38,7 @@ class CustomDataSerializationTest: StringSpec( {
         request.action shouldBe "Heartbeat"
         val parsedPayload = messageSerializer.deserializePayload(request, HeartbeatRequest::class.java)
         (parsedPayload is ParsingResult.Success<HeartbeatRequest>) shouldBe true
+        (parsedPayload as ParsingResult.Success<HeartbeatRequest>).value.customData?.vendorId shouldBe "testVendor"
+        parsedPayload.value.customData?.get("testKey") shouldBe "testValue"
     }
 })

--- a/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/CustomDataSerializationTest.kt
+++ b/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/CustomDataSerializationTest.kt
@@ -1,0 +1,42 @@
+package com.monta.library.ocpp.v201.blocks
+
+import com.monta.library.ocpp.common.serialization.Message
+import com.monta.library.ocpp.common.serialization.MessageSerializer
+import com.monta.library.ocpp.common.serialization.ParsingResult
+import com.monta.library.ocpp.common.serialization.SerializationMode
+import com.monta.library.ocpp.v201.blocks.availability.HeartbeatRequest
+import com.monta.library.ocpp.v201.common.CustomData
+import com.monta.library.ocpp.v201.error.OcppErrorResponderV201
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class CustomDataSerializationTest: StringSpec( {
+    val messageSerializer = MessageSerializer(SerializationMode.OCPP_2, OcppErrorResponderV201)
+
+    "custom data (de)serialization should work" {
+        val x: HashMap<String, String> = HashMap()
+        x["vendorId"] = "testVendor"
+        x["testKey"] = "testValue"
+        val heartbeatRequest = Message.Request(
+            "123",
+            "Heartbeat",
+            messageSerializer.toPayload(
+                HeartbeatRequest(customData = x as CustomData)) // fails, can't even construct CustomData, because it validates before it has data
+            )
+        val serialized = heartbeatRequest.toJsonString(messageSerializer)
+        serialized shouldBe "[2,\"123\",\"Heartbeat\",{\"customData\":{\"vendorId\":\"testVendor\",\"testKey\":\"testValue\"}}]"
+    }
+
+    "deserialization" {
+        val serialized = "[2,\"123\",\"Heartbeat\",{\"customData\":{\"vendorId\":\"testVendor\",\"testKey\":\"testValue\"}}]"
+        val parsed = messageSerializer.parse(serialized)
+        (parsed is ParsingResult.Success<Message>) shouldBe true
+        val message = (parsed as ParsingResult.Success<Message>).value
+        (message is Message.Request) shouldBe true
+        val request = message as Message.Request
+        request.uniqueId shouldBe "123"
+        request.action shouldBe "Heartbeat"
+        val parsedPayload = messageSerializer.deserializePayload(request, HeartbeatRequest::class.java)
+        (parsedPayload is ParsingResult.Success<HeartbeatRequest>) shouldBe true
+    }
+})


### PR DESCRIPTION
# Description

## What?

Remove the vendorId length validation in the CustomData init

## Why?

Cannot even construct an instance of CustomData currently, resulting in FormationViolation errors. This is a quick fix to get our integration testing unblocked.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
