### PR TITLE
feat: enable PR and JIRA comments in changelog [SRE-1580]

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,9 +25,24 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      publish-start-time: ${{ steps.set-start-time.outputs.time }}
+      publish-end-time: ${{ steps.set-end-time.outputs.time }}
+      version: ${{ steps.get-version.outputs.version }}
     steps:
+      - name: Set publish start time
+        id: set-start-time
+        run: echo "time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Get current version from tag
+        id: get-version
+        run: |
+          VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Current version: $VERSION"
       # Setup JDK
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -40,6 +55,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew --no-daemon publish
+
+      - name: Set publish end time
+        id: set-end-time
+        run: echo "time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
   create-change-log:
     needs: publish
     name: Create and publish change log
@@ -51,10 +70,19 @@ jobs:
         with:
           service-name: "OCPP Library"
           github-release: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.MONTA_GITHUB_TOKEN }}
           jira-app-name: "montaapp"
+          jira-email: ${{ secrets.JIRA_EMAIL }}
+          jira-token: ${{ secrets.JIRA_TOKEN }}
           version-mode: "SemVer"
           output: "slack"
           slack-token: ${{ secrets.SLACK_APP_TOKEN }}
           # Slack channel: C02PDBL6GAU = #info-releases
           slack-channel: "C02PDBL6GAU"
+          # Metadata for PR/JIRA comments
+          stage: "production"
+          deployment-start-time: ${{ needs.publish.outputs.publish-start-time }}
+          deployment-end-time: ${{ needs.publish.outputs.publish-end-time }}
+          deployment-url: "https://github.com/monta-app/library-ocpp/releases/tag/v${{ needs.publish.outputs.version }}"
+          comment-on-prs: true
+          comment-on-jira: true


### PR DESCRIPTION
## Summary

Enables PR and JIRA comment features for the OCPP Library publishing workflow.

## Changes

- ✅ Capture publish timing (start/end timestamps)
- ✅ Extract version from git tag for deployment URL
- ✅ Use `MONTA_GITHUB_TOKEN` for `github-token` (proper user attribution)
- ✅ Add JIRA credentials (`jira-email`, `jira-token`)
- ✅ Add minimal metadata for library publishing:
  - `stage: production` (publishing = production)
  - `deployment-start-time`, `deployment-end-time` (publish timing)
  - `deployment-url` (GitHub Release URL)
- ✅ Enable `comment-on-prs: true`
- ✅ Enable `comment-on-jira: true`

## Impact

When a library version is published, the changelog action will:
- ✅ Comment on merged PRs with release information
- ✅ Comment on JIRA tickets with release information
- ✅ Include version, timing, and GitHub Release links

## Pattern

Follows the minimal metadata approach established in library-kotlin PR #532:
- **No fake docker/image metadata** for libraries
- Only capture what's actually relevant: stage, timing, release URL

## Related

- Part of SRE-1580 rollout
- Follows library-kotlin pattern (PR #532)
- Test case: library-kotlin validates this approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)