### PR TITLE
chore: migrate CI runners to ARM64

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,6 +14,7 @@ jobs:
     uses: monta-app/github-workflows/.github/workflows/pull-request-kotlin.yml@main
     with:
       skip-sonar: true
+      architecture: "arm64"
       kover-report-path: "core/build/reports/kover/report.xml"
     secrets:
       GHL_USERNAME: ${{ secrets.GHL_USERNAME }}


### PR DESCRIPTION
## Summary
- Switch CI runner architecture from `x64` (default) to `arm64`
- Saves ~36% on large runner costs ($0.014/min vs $0.022/min for 8-core)
- Saves ~17% on normal runner costs ($0.005/min vs $0.006/min for 2-core)
- All Kotlin services already run on ARM in production
- JVM bytecode is architecture-independent, so no code changes needed

## Changes
- Added `architecture: "arm64"` to shared workflow `with:` inputs

## Test plan
- [ ] Verify PR checks pass on ARM runners
- [ ] If any issues: revert by removing the `architecture` line (falls back to x64 default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
