### PR TITLE
feat(smartcharging): floor limit and minChargingRate to 1 decimal [SUPPORT-6719]

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,7 +15,6 @@ jobs:
     with:
       skip-sonar: true
       architecture: "arm64"
-      kover-report-path: "core/build/reports/kover/report.xml"
     secrets:
       GHL_USERNAME: ${{ secrets.GHL_USERNAME }}
       GHL_PASSWORD: ${{ secrets.GHL_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     // Linter
     alias(libs.plugins.ktlint)
     // Code coverage
-    alias(libs.plugins.kover) apply false
+    alias(libs.plugins.kover) apply true
     // Apply the java-library plugin for API and implementation separation.
     `java-library`
 }
@@ -26,4 +26,11 @@ allprojects {
             }
         }
     }
+}
+
+dependencies {
+    kover(project(":core"))
+    kover(project(":v16"))
+    kover(project(":v201"))
+    kover(project(":server"))
 }

--- a/core/src/main/kotlin/com/monta/library/ocpp/common/serialization/ChargingRateScaleSerializer.kt
+++ b/core/src/main/kotlin/com/monta/library/ocpp/common/serialization/ChargingRateScaleSerializer.kt
@@ -11,12 +11,12 @@ import java.math.RoundingMode
 
 class OneDecimalFloorSerializer : StdSerializer<Double>(Double::class.java) {
     override fun serialize(value: Double, gen: JsonGenerator, provider: SerializerProvider) {
-        gen.writeNumber(BigDecimal(value).setScale(1, RoundingMode.FLOOR).toDouble())
+        gen.writeNumber(BigDecimal(value).setScale(1, RoundingMode.HALF_UP).toDouble())
     }
 }
 
 class OneDecimalFloorDeserializer : StdDeserializer<Double>(Double::class.java) {
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Double {
-        return BigDecimal(p.doubleValue).setScale(1, RoundingMode.FLOOR).toDouble()
+        return BigDecimal(p.doubleValue).setScale(1, RoundingMode.HALF_UP).toDouble()
     }
 }

--- a/core/src/main/kotlin/com/monta/library/ocpp/common/serialization/ChargingRateScaleSerializer.kt
+++ b/core/src/main/kotlin/com/monta/library/ocpp/common/serialization/ChargingRateScaleSerializer.kt
@@ -1,0 +1,22 @@
+package com.monta.library.ocpp.common.serialization
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+class OneDecimalFloorSerializer : StdSerializer<Double>(Double::class.java) {
+    override fun serialize(value: Double, gen: JsonGenerator, provider: SerializerProvider) {
+        gen.writeNumber(BigDecimal(value).setScale(1, RoundingMode.FLOOR).toDouble())
+    }
+}
+
+class OneDecimalFloorDeserializer : StdDeserializer<Double>(Double::class.java) {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Double {
+        return BigDecimal(p.doubleValue).setScale(1, RoundingMode.FLOOR).toDouble()
+    }
+}

--- a/v16/src/main/kotlin/com/monta/library/ocpp/v16/smartcharge/ChargingProfile.kt
+++ b/v16/src/main/kotlin/com/monta/library/ocpp/v16/smartcharge/ChargingProfile.kt
@@ -1,10 +1,14 @@
 package com.monta.library.ocpp.v16.smartcharge
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.monta.library.ocpp.common.chargingprofile.ChargingProfileKind
 import com.monta.library.ocpp.common.chargingprofile.ChargingRateUnit
 import com.monta.library.ocpp.common.chargingprofile.CommonChargingProfile
 import com.monta.library.ocpp.common.chargingprofile.CommonChargingProfilePurpose
 import com.monta.library.ocpp.common.chargingprofile.RecurrencyKind
+import com.monta.library.ocpp.common.serialization.OneDecimalFloorDeserializer
+import com.monta.library.ocpp.common.serialization.OneDecimalFloorSerializer
 import com.monta.library.ocpp.common.toZonedDateTime
 import java.time.ZonedDateTime
 
@@ -28,6 +32,8 @@ enum class ChargingProfilePurposeType {
 
 data class ChargingSchedulePeriod(
     val startPeriod: Int? = null,
+    @param:JsonSerialize(using = OneDecimalFloorSerializer::class)
+    @param:JsonDeserialize(using = OneDecimalFloorDeserializer::class)
     val limit: Double? = null,
     val numberPhases: Int = 3
 ) {
@@ -49,6 +55,8 @@ data class ChargingSchedule(
     val startSchedule: ZonedDateTime? = null,
     val chargingRateUnit: ChargingRateUnit? = null,
     val chargingSchedulePeriod: List<ChargingSchedulePeriod>,
+    @param:JsonSerialize(using = OneDecimalFloorSerializer::class)
+    @param:JsonDeserialize(using = OneDecimalFloorDeserializer::class)
     var minChargingRate: Double? = null
 ) {
     companion object {

--- a/v16/src/test/kotlin/com/monta/library/ocpp/profiles/serialization/GetCompositeScheduleSerializationTest.kt
+++ b/v16/src/test/kotlin/com/monta/library/ocpp/profiles/serialization/GetCompositeScheduleSerializationTest.kt
@@ -68,6 +68,6 @@ class GetCompositeScheduleSerializationTest : StringSpec({
         )
 
         messageSerializer.toPayloadString(confirmation) shouldBe
-            """{"status":"Accepted","connectorId":1,"chargingSchedule":{"duration":60,"chargingRateUnit":"A","chargingSchedulePeriod":[{"startPeriod":0,"limit":32.1,"numberPhases":1}],"minChargingRate":15.6}}"""
+            """{"status":"Accepted","connectorId":1,"chargingSchedule":{"duration":60,"chargingRateUnit":"A","chargingSchedulePeriod":[{"startPeriod":0,"limit":32.1,"numberPhases":1}],"minChargingRate":15.7}}"""
     }
 })

--- a/v16/src/test/kotlin/com/monta/library/ocpp/profiles/serialization/GetCompositeScheduleSerializationTest.kt
+++ b/v16/src/test/kotlin/com/monta/library/ocpp/profiles/serialization/GetCompositeScheduleSerializationTest.kt
@@ -7,6 +7,8 @@ import com.monta.library.ocpp.common.serialization.MessageSerializer
 import com.monta.library.ocpp.common.serialization.ParsingResult
 import com.monta.library.ocpp.common.serialization.SerializationMode
 import com.monta.library.ocpp.v16.error.OcppErrorResponderV16
+import com.monta.library.ocpp.v16.smartcharge.ChargingSchedule
+import com.monta.library.ocpp.v16.smartcharge.ChargingSchedulePeriod
 import com.monta.library.ocpp.v16.smartcharge.GetCompositeScheduleConfirmation
 import com.monta.library.ocpp.v16.smartcharge.GetCompositeScheduleStatus
 import io.kotest.core.spec.style.StringSpec
@@ -26,7 +28,7 @@ class GetCompositeScheduleSerializationTest : StringSpec({
 
         ocppMessage.shouldBeInstanceOf<Message.Response>()
         ocppMessage.uniqueId shouldBe "d16cd067-9506-441e-902b-af1b9b15b8e4"
-        ocppMessage.payload shouldBe TestUtils.toJsonNode("{\"status\":\"Accepted\",\"connectorId\":1,\"scheduleStart\":\"2025-05-22T08:29:27.000Z\",\"chargingSchedule\":{\"duration\":60,\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":32,\"numberPhases\":1}],\"minChargingRate\":0}}")
+        ocppMessage.payload shouldBe TestUtils.toJsonNode("{\"status\":\"Accepted\",\"connectorId\":1,\"scheduleStart\":\"2025-05-22T08:29:27.000Z\",\"chargingSchedule\":{\"duration\":60,\"chargingRateUnit\":\"A\",\"chargingSchedulePeriod\":[{\"startPeriod\":0,\"limit\":32.123,\"numberPhases\":1}],\"minChargingRate\":0.1234}}")
 
         val response = messageSerializer.deserializePayload(ocppMessage, GetCompositeScheduleConfirmation::class.java)
         response.shouldBeInstanceOf<ParsingResult.Success<GetCompositeScheduleConfirmation>>()
@@ -37,13 +39,35 @@ class GetCompositeScheduleSerializationTest : StringSpec({
         payload.chargingSchedule shouldNotBeNull {
             chargingRateUnit shouldBe ChargingRateUnit.A
             duration shouldBe 60
-            minChargingRate shouldBe 0.0
+            minChargingRate shouldBe 0.1
             chargingSchedulePeriod shouldNotBeNull {
                 size shouldBe 1
                 this[0].startPeriod shouldBe 0
-                this[0].limit shouldBe 32.0
+                this[0].limit shouldBe 32.1
                 this[0].numberPhases shouldBe 1
             }
         }
+    }
+
+    "serialize a get composite schedule response and floor limit and minChargingRate to 1 decimal" {
+        val confirmation = GetCompositeScheduleConfirmation(
+            status = GetCompositeScheduleStatus.Accepted,
+            connectorId = 1,
+            chargingSchedule = ChargingSchedule(
+                duration = 60,
+                chargingRateUnit = ChargingRateUnit.A,
+                chargingSchedulePeriod = listOf(
+                    ChargingSchedulePeriod(
+                        startPeriod = 0,
+                        limit = 32.123,
+                        numberPhases = 1
+                    )
+                ),
+                minChargingRate = 15.678
+            )
+        )
+
+        messageSerializer.toPayloadString(confirmation) shouldBe
+            """{"status":"Accepted","connectorId":1,"chargingSchedule":{"duration":60,"chargingRateUnit":"A","chargingSchedulePeriod":[{"startPeriod":0,"limit":32.1,"numberPhases":1}],"minChargingRate":15.6}}"""
     }
 })

--- a/v16/src/test/kotlin/com/monta/library/ocpp/profiles/serialization/SetChargingProfileSerializationTest.kt
+++ b/v16/src/test/kotlin/com/monta/library/ocpp/profiles/serialization/SetChargingProfileSerializationTest.kt
@@ -45,14 +45,14 @@ class SetChargingProfileSerializationTest : StringSpec({
             chargingProfileKind shouldBe ChargingProfileKind.Absolute
             chargingSchedule shouldNotBeNull {
                 chargingRateUnit shouldBe ChargingRateUnit.A
-                minChargingRate shouldBe 6.9
+                minChargingRate shouldBe 7.0
                 chargingSchedulePeriod shouldNotBeNull {
                     size shouldBe 2
                     this[0].startPeriod shouldBe 0
-                    this[0].limit shouldBe 16.7
+                    this[0].limit shouldBe 16.8
                     this[0].numberPhases shouldBe 3
                     this[1].startPeriod shouldBe 3600
-                    this[1].limit shouldBe 10.4
+                    this[1].limit shouldBe 10.5
                     this[1].numberPhases shouldBe 3
                 }
             }
@@ -79,6 +79,6 @@ class SetChargingProfileSerializationTest : StringSpec({
         )
 
         messageSerializer.toPayloadString(request) shouldBe
-            """{"connectorId":1,"csChargingProfiles":{"chargingProfileId":42,"stackLevel":0,"chargingProfilePurpose":"TxDefaultProfile","chargingProfileKind":"Absolute","chargingSchedule":{"chargingRateUnit":"A","chargingSchedulePeriod":[{"startPeriod":0,"limit":16.7,"numberPhases":3},{"startPeriod":3600,"limit":10.4,"numberPhases":3}],"minChargingRate":6.9}}}"""
+            """{"connectorId":1,"csChargingProfiles":{"chargingProfileId":42,"stackLevel":0,"chargingProfilePurpose":"TxDefaultProfile","chargingProfileKind":"Absolute","chargingSchedule":{"chargingRateUnit":"A","chargingSchedulePeriod":[{"startPeriod":0,"limit":16.8,"numberPhases":3},{"startPeriod":3600,"limit":10.5,"numberPhases":3}],"minChargingRate":7.0}}}"""
     }
 })

--- a/v16/src/test/kotlin/com/monta/library/ocpp/profiles/serialization/SetChargingProfileSerializationTest.kt
+++ b/v16/src/test/kotlin/com/monta/library/ocpp/profiles/serialization/SetChargingProfileSerializationTest.kt
@@ -1,0 +1,84 @@
+package com.monta.library.ocpp.profiles.serialization
+
+import com.monta.library.ocpp.TestUtils
+import com.monta.library.ocpp.common.chargingprofile.ChargingProfileKind
+import com.monta.library.ocpp.common.chargingprofile.ChargingRateUnit
+import com.monta.library.ocpp.common.serialization.Message
+import com.monta.library.ocpp.common.serialization.MessageSerializer
+import com.monta.library.ocpp.common.serialization.ParsingResult
+import com.monta.library.ocpp.common.serialization.SerializationMode
+import com.monta.library.ocpp.v16.error.OcppErrorResponderV16
+import com.monta.library.ocpp.v16.smartcharge.ChargingProfile
+import com.monta.library.ocpp.v16.smartcharge.ChargingProfilePurposeType
+import com.monta.library.ocpp.v16.smartcharge.ChargingSchedule
+import com.monta.library.ocpp.v16.smartcharge.ChargingSchedulePeriod
+import com.monta.library.ocpp.v16.smartcharge.SetChargingProfileRequest
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class SetChargingProfileSerializationTest : StringSpec({
+    val messageSerializer = MessageSerializer(SerializationMode.OCPP_1_6, OcppErrorResponderV16)
+
+    "parse a valid set charging profile request and floor limit and minChargingRate to 1 decimal" {
+        val jsonString = TestUtils.getFileAsString("smartcharge/set-charging-profile-req.json")
+        val parsingResult = messageSerializer.parse(jsonString)
+
+        parsingResult.shouldBeInstanceOf<ParsingResult.Success<Message.Request>>()
+        val ocppMessage = parsingResult.value
+
+        ocppMessage.shouldBeInstanceOf<Message.Request>()
+        ocppMessage.uniqueId shouldBe "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        ocppMessage.payload shouldBe TestUtils.toJsonNode(
+            """{"connectorId":1,"csChargingProfiles":{"chargingProfileId":42,"stackLevel":0,"chargingProfilePurpose":"TxDefaultProfile","chargingProfileKind":"Absolute","chargingSchedule":{"chargingRateUnit":"A","chargingSchedulePeriod":[{"startPeriod":0,"limit":16.789,"numberPhases":3},{"startPeriod":3600,"limit":10.456,"numberPhases":3}],"minChargingRate":6.999}}}"""
+        )
+
+        val request = messageSerializer.deserializePayload(ocppMessage, SetChargingProfileRequest::class.java)
+        request.shouldBeInstanceOf<ParsingResult.Success<SetChargingProfileRequest>>()
+        val payload = request.value
+        payload.connectorId shouldBe 1
+        payload.csChargingProfiles shouldNotBeNull {
+            chargingProfileId shouldBe 42
+            stackLevel shouldBe 0
+            chargingProfilePurpose shouldBe ChargingProfilePurposeType.TxDefaultProfile
+            chargingProfileKind shouldBe ChargingProfileKind.Absolute
+            chargingSchedule shouldNotBeNull {
+                chargingRateUnit shouldBe ChargingRateUnit.A
+                minChargingRate shouldBe 6.9
+                chargingSchedulePeriod shouldNotBeNull {
+                    size shouldBe 2
+                    this[0].startPeriod shouldBe 0
+                    this[0].limit shouldBe 16.7
+                    this[0].numberPhases shouldBe 3
+                    this[1].startPeriod shouldBe 3600
+                    this[1].limit shouldBe 10.4
+                    this[1].numberPhases shouldBe 3
+                }
+            }
+        }
+    }
+
+    "serialize a set charging profile request and floor limit and minChargingRate to 1 decimal" {
+        val request = SetChargingProfileRequest(
+            connectorId = 1,
+            csChargingProfiles = ChargingProfile(
+                chargingProfileId = 42,
+                stackLevel = 0,
+                chargingProfilePurpose = ChargingProfilePurposeType.TxDefaultProfile,
+                chargingProfileKind = ChargingProfileKind.Absolute,
+                chargingSchedule = ChargingSchedule(
+                    chargingRateUnit = ChargingRateUnit.A,
+                    chargingSchedulePeriod = listOf(
+                        ChargingSchedulePeriod(startPeriod = 0, limit = 16.789, numberPhases = 3),
+                        ChargingSchedulePeriod(startPeriod = 3600, limit = 10.456, numberPhases = 3)
+                    ),
+                    minChargingRate = 6.999
+                )
+            )
+        )
+
+        messageSerializer.toPayloadString(request) shouldBe
+            """{"connectorId":1,"csChargingProfiles":{"chargingProfileId":42,"stackLevel":0,"chargingProfilePurpose":"TxDefaultProfile","chargingProfileKind":"Absolute","chargingSchedule":{"chargingRateUnit":"A","chargingSchedulePeriod":[{"startPeriod":0,"limit":16.7,"numberPhases":3},{"startPeriod":3600,"limit":10.4,"numberPhases":3}],"minChargingRate":6.9}}}"""
+    }
+})

--- a/v16/src/test/resources/smartcharge/get-composite-schedule-resp.json
+++ b/v16/src/test/resources/smartcharge/get-composite-schedule-resp.json
@@ -11,11 +11,11 @@
       "chargingSchedulePeriod": [
         {
           "startPeriod": 0,
-          "limit": 32,
+          "limit": 32.123,
           "numberPhases": 1
         }
       ],
-      "minChargingRate": 0
+      "minChargingRate": 0.1234
     }
   }
 ]

--- a/v16/src/test/resources/smartcharge/set-charging-profile-req.json
+++ b/v16/src/test/resources/smartcharge/set-charging-profile-req.json
@@ -1,0 +1,30 @@
+[
+  2,
+  "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "SetChargingProfile",
+  {
+    "connectorId": 1,
+    "csChargingProfiles": {
+      "chargingProfileId": 42,
+      "stackLevel": 0,
+      "chargingProfilePurpose": "TxDefaultProfile",
+      "chargingProfileKind": "Absolute",
+      "chargingSchedule": {
+        "chargingRateUnit": "A",
+        "chargingSchedulePeriod": [
+          {
+            "startPeriod": 0,
+            "limit": 16.789,
+            "numberPhases": 3
+          },
+          {
+            "startPeriod": 3600,
+            "limit": 10.456,
+            "numberPhases": 3
+          }
+        ],
+        "minChargingRate": 6.999
+      }
+    }
+  }
+]

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/common/chargingprofile/ChargingSchedule.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/common/chargingprofile/ChargingSchedule.kt
@@ -1,7 +1,11 @@
 package com.monta.library.ocpp.v201.common.chargingprofile
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.monta.library.ocpp.common.chargingprofile.ChargingRateUnit
 import com.monta.library.ocpp.common.chargingprofile.CommonChargingProfile
+import com.monta.library.ocpp.common.serialization.OneDecimalFloorDeserializer
+import com.monta.library.ocpp.common.serialization.OneDecimalFloorSerializer
 import com.monta.library.ocpp.common.toZonedDateTime
 import com.monta.library.ocpp.v201.common.CustomData
 import java.time.ZonedDateTime
@@ -22,6 +26,8 @@ data class ChargingSchedule(
     /** Charging_ Schedule. Min_ Charging_ Rate. Numeric
      urn:x-oca:ocpp:uid:1:569239
      Minimum charging rate supported by the EV. The unit of measure is defined by the chargingRateUnit. This parameter is intended to be used by a local smart charging algorithm to optimize the power allocation for in the case a charging process is inefficient at lower charging rates. Accepts at most one digit fraction (e.g. 8.1) */
+    @param:JsonSerialize(using = OneDecimalFloorSerializer::class)
+    @param:JsonDeserialize(using = OneDecimalFloorDeserializer::class)
     val minChargingRate: Double? = null,
     val salesTariff: SalesTariff? = null,
     val customData: CustomData? = null

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/common/chargingprofile/ChargingSchedulePeriod.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/common/chargingprofile/ChargingSchedulePeriod.kt
@@ -1,6 +1,10 @@
 package com.monta.library.ocpp.v201.common.chargingprofile
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.monta.library.ocpp.common.chargingprofile.CommonChargingProfile
+import com.monta.library.ocpp.common.serialization.OneDecimalFloorDeserializer
+import com.monta.library.ocpp.common.serialization.OneDecimalFloorSerializer
 import com.monta.library.ocpp.v201.common.CustomData
 
 data class ChargingSchedulePeriod(
@@ -14,6 +18,8 @@ data class ChargingSchedulePeriod(
      * for example in Amperes (A) or Watts (W).
      * Accepts at most one digit fraction (e.g. 8.1).
      **/
+    @param:JsonSerialize(using = OneDecimalFloorSerializer::class)
+    @param:JsonDeserialize(using = OneDecimalFloorDeserializer::class)
     val limit: Double,
     /**
      * The number of phases that can be used for charging.

--- a/v201/src/test/kotlin/com/monta/library/ocpp/TestUtils.kt
+++ b/v201/src/test/kotlin/com/monta/library/ocpp/TestUtils.kt
@@ -1,0 +1,16 @@
+package com.monta.library.ocpp
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+object TestUtils {
+    private val objectMapper = jacksonObjectMapper()
+
+    fun getFileAsString(filename: String): String {
+        return requireNotNull(object {}.javaClass.classLoader.getResource(filename)).readText()
+    }
+
+    fun toJsonNode(value: String): JsonNode {
+        return objectMapper.readTree(value)
+    }
+}

--- a/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/smartcharging/GetCompositeScheduleSerializationTest.kt
+++ b/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/smartcharging/GetCompositeScheduleSerializationTest.kt
@@ -1,0 +1,72 @@
+package com.monta.library.ocpp.v201.blocks.smartcharging
+
+import com.monta.library.ocpp.TestUtils
+import com.monta.library.ocpp.common.chargingprofile.ChargingRateUnit
+import com.monta.library.ocpp.common.serialization.Message
+import com.monta.library.ocpp.common.serialization.MessageSerializer
+import com.monta.library.ocpp.common.serialization.ParsingResult
+import com.monta.library.ocpp.common.serialization.SerializationMode
+import com.monta.library.ocpp.v201.common.GenericStatus
+import com.monta.library.ocpp.v201.common.chargingprofile.ChargingSchedulePeriod
+import com.monta.library.ocpp.v201.error.OcppErrorResponderV201
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.time.ZonedDateTime
+
+class GetCompositeScheduleSerializationTest : StringSpec({
+    val messageSerializer = MessageSerializer(SerializationMode.OCPP_2, OcppErrorResponderV201)
+
+    "parse a valid get composite schedule response and floor limit to 1 decimal" {
+        val jsonString = TestUtils.getFileAsString("smartcharging/get-composite-schedule-resp.json")
+        val parsingResult = messageSerializer.parse(jsonString)
+
+        parsingResult.shouldBeInstanceOf<ParsingResult.Success<Message.Response>>()
+        val ocppMessage = parsingResult.value
+
+        ocppMessage.shouldBeInstanceOf<Message.Response>()
+        ocppMessage.uniqueId shouldBe "c3d4e5f6-a7b8-9012-cdef-123456789012"
+        ocppMessage.payload shouldBe TestUtils.toJsonNode(
+            """{"status":"Accepted","schedule":{"evseId":1,"duration":3600,"scheduleStart":"2025-05-22T08:29:27.000Z","chargingRateUnit":"A","chargingSchedulePeriod":[{"startPeriod":0,"limit":32.123,"numberPhases":3},{"startPeriod":1800,"limit":20.567,"numberPhases":3}]}}"""
+        )
+
+        val response = messageSerializer.deserializePayload(ocppMessage, GetCompositeScheduleResponse::class.java)
+        response.shouldBeInstanceOf<ParsingResult.Success<GetCompositeScheduleResponse>>()
+        val payload = response.value
+        payload.status shouldBe GenericStatus.Accepted
+        payload.schedule shouldNotBeNull {
+            evseId shouldBe 1L
+            duration shouldBe 3600L
+            chargingRateUnit shouldBe ChargingRateUnit.A
+            chargingSchedulePeriod shouldNotBeNull {
+                size shouldBe 2
+                this[0].startPeriod shouldBe 0
+                this[0].limit shouldBe 32.1
+                this[0].numberPhases shouldBe 3
+                this[1].startPeriod shouldBe 1800
+                this[1].limit shouldBe 20.5
+                this[1].numberPhases shouldBe 3
+            }
+        }
+    }
+
+    "serialize a get composite schedule response and floor limit to 1 decimal" {
+        val response = GetCompositeScheduleResponse(
+            status = GenericStatus.Accepted,
+            schedule = GetCompositeScheduleResponse.CompositeSchedule(
+                evseId = 1L,
+                duration = 3600L,
+                scheduleStart = ZonedDateTime.parse("2025-05-22T08:29:27Z"),
+                chargingRateUnit = ChargingRateUnit.A,
+                chargingSchedulePeriod = listOf(
+                    ChargingSchedulePeriod(startPeriod = 0, limit = 32.123, numberPhases = 3),
+                    ChargingSchedulePeriod(startPeriod = 1800, limit = 20.567, numberPhases = 3)
+                )
+            )
+        )
+
+        messageSerializer.toPayloadString(response) shouldBe
+            """{"status":"Accepted","schedule":{"chargingSchedulePeriod":[{"startPeriod":0,"limit":32.1,"numberPhases":3},{"startPeriod":1800,"limit":20.5,"numberPhases":3}],"evseId":1,"duration":3600,"scheduleStart":"2025-05-22T08:29:27.000Z","chargingRateUnit":"A"}}"""
+    }
+})

--- a/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/smartcharging/GetCompositeScheduleSerializationTest.kt
+++ b/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/smartcharging/GetCompositeScheduleSerializationTest.kt
@@ -45,7 +45,7 @@ class GetCompositeScheduleSerializationTest : StringSpec({
                 this[0].limit shouldBe 32.1
                 this[0].numberPhases shouldBe 3
                 this[1].startPeriod shouldBe 1800
-                this[1].limit shouldBe 20.5
+                this[1].limit shouldBe 20.6
                 this[1].numberPhases shouldBe 3
             }
         }
@@ -67,6 +67,6 @@ class GetCompositeScheduleSerializationTest : StringSpec({
         )
 
         messageSerializer.toPayloadString(response) shouldBe
-            """{"status":"Accepted","schedule":{"chargingSchedulePeriod":[{"startPeriod":0,"limit":32.1,"numberPhases":3},{"startPeriod":1800,"limit":20.5,"numberPhases":3}],"evseId":1,"duration":3600,"scheduleStart":"2025-05-22T08:29:27.000Z","chargingRateUnit":"A"}}"""
+            """{"status":"Accepted","schedule":{"chargingSchedulePeriod":[{"startPeriod":0,"limit":32.1,"numberPhases":3},{"startPeriod":1800,"limit":20.6,"numberPhases":3}],"evseId":1,"duration":3600,"scheduleStart":"2025-05-22T08:29:27.000Z","chargingRateUnit":"A"}}"""
     }
 })

--- a/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/smartcharging/SetChargingProfileSerializationTest.kt
+++ b/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/smartcharging/SetChargingProfileSerializationTest.kt
@@ -45,14 +45,14 @@ class SetChargingProfileSerializationTest : StringSpec({
             chargingSchedule shouldNotBeNull {
                 size shouldBe 1
                 this[0].chargingRateUnit shouldBe ChargingRateUnit.A
-                this[0].minChargingRate shouldBe 6.9
+                this[0].minChargingRate shouldBe 7.0
                 this[0].chargingSchedulePeriod shouldNotBeNull {
                     size shouldBe 2
                     this[0].startPeriod shouldBe 0
-                    this[0].limit shouldBe 16.7
+                    this[0].limit shouldBe 16.8
                     this[0].numberPhases shouldBe 3
                     this[1].startPeriod shouldBe 3600
-                    this[1].limit shouldBe 10.4
+                    this[1].limit shouldBe 10.5
                     this[1].numberPhases shouldBe 3
                 }
             }
@@ -82,6 +82,6 @@ class SetChargingProfileSerializationTest : StringSpec({
         )
 
         messageSerializer.toPayloadString(request) shouldBe
-            """{"evseId":1,"chargingProfile":{"id":99,"stackLevel":0,"chargingProfilePurpose":"TxDefaultProfile","chargingProfileKind":"Absolute","chargingSchedule":[{"id":1,"chargingRateUnit":"A","chargingSchedulePeriod":[{"startPeriod":0,"limit":16.7,"numberPhases":3},{"startPeriod":3600,"limit":10.4,"numberPhases":3}],"minChargingRate":6.9}]}}"""
+            """{"evseId":1,"chargingProfile":{"id":99,"stackLevel":0,"chargingProfilePurpose":"TxDefaultProfile","chargingProfileKind":"Absolute","chargingSchedule":[{"id":1,"chargingRateUnit":"A","chargingSchedulePeriod":[{"startPeriod":0,"limit":16.8,"numberPhases":3},{"startPeriod":3600,"limit":10.5,"numberPhases":3}],"minChargingRate":7.0}]}}"""
     }
 })

--- a/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/smartcharging/SetChargingProfileSerializationTest.kt
+++ b/v201/src/test/kotlin/com/monta/library/ocpp/v201/blocks/smartcharging/SetChargingProfileSerializationTest.kt
@@ -1,0 +1,87 @@
+package com.monta.library.ocpp.v201.blocks.smartcharging
+
+import com.monta.library.ocpp.TestUtils
+import com.monta.library.ocpp.common.chargingprofile.ChargingProfileKind
+import com.monta.library.ocpp.common.chargingprofile.ChargingRateUnit
+import com.monta.library.ocpp.common.serialization.Message
+import com.monta.library.ocpp.common.serialization.MessageSerializer
+import com.monta.library.ocpp.common.serialization.ParsingResult
+import com.monta.library.ocpp.common.serialization.SerializationMode
+import com.monta.library.ocpp.v201.common.chargingprofile.ChargingProfile
+import com.monta.library.ocpp.v201.common.chargingprofile.ChargingProfilePurpose
+import com.monta.library.ocpp.v201.common.chargingprofile.ChargingSchedule
+import com.monta.library.ocpp.v201.common.chargingprofile.ChargingSchedulePeriod
+import com.monta.library.ocpp.v201.error.OcppErrorResponderV201
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class SetChargingProfileSerializationTest : StringSpec({
+    val messageSerializer = MessageSerializer(SerializationMode.OCPP_2, OcppErrorResponderV201)
+
+    "parse a valid set charging profile request and floor limit and minChargingRate to 1 decimal" {
+        val jsonString = TestUtils.getFileAsString("smartcharging/set-charging-profile-req.json")
+        val parsingResult = messageSerializer.parse(jsonString)
+
+        parsingResult.shouldBeInstanceOf<ParsingResult.Success<Message.Request>>()
+        val ocppMessage = parsingResult.value
+
+        ocppMessage.shouldBeInstanceOf<Message.Request>()
+        ocppMessage.uniqueId shouldBe "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+        ocppMessage.payload shouldBe TestUtils.toJsonNode(
+            """{"evseId":1,"chargingProfile":{"id":99,"stackLevel":0,"chargingProfilePurpose":"TxDefaultProfile","chargingProfileKind":"Absolute","chargingSchedule":[{"id":1,"chargingRateUnit":"A","chargingSchedulePeriod":[{"startPeriod":0,"limit":16.789,"numberPhases":3},{"startPeriod":3600,"limit":10.456,"numberPhases":3}],"minChargingRate":6.999}]}}"""
+        )
+
+        val request = messageSerializer.deserializePayload(ocppMessage, SetChargingProfileRequest::class.java)
+        request.shouldBeInstanceOf<ParsingResult.Success<SetChargingProfileRequest>>()
+        val payload = request.value
+        payload.evseId shouldBe 1L
+        payload.chargingProfile shouldNotBeNull {
+            id shouldBe 99
+            stackLevel shouldBe 0
+            chargingProfilePurpose shouldBe ChargingProfilePurpose.TxDefaultProfile
+            chargingProfileKind shouldBe ChargingProfileKind.Absolute
+            chargingSchedule shouldNotBeNull {
+                size shouldBe 1
+                this[0].chargingRateUnit shouldBe ChargingRateUnit.A
+                this[0].minChargingRate shouldBe 6.9
+                this[0].chargingSchedulePeriod shouldNotBeNull {
+                    size shouldBe 2
+                    this[0].startPeriod shouldBe 0
+                    this[0].limit shouldBe 16.7
+                    this[0].numberPhases shouldBe 3
+                    this[1].startPeriod shouldBe 3600
+                    this[1].limit shouldBe 10.4
+                    this[1].numberPhases shouldBe 3
+                }
+            }
+        }
+    }
+
+    "serialize a set charging profile request and floor limit and minChargingRate to 1 decimal" {
+        val request = SetChargingProfileRequest(
+            evseId = 1L,
+            chargingProfile = ChargingProfile(
+                id = 99,
+                stackLevel = 0,
+                chargingProfilePurpose = ChargingProfilePurpose.TxDefaultProfile,
+                chargingProfileKind = ChargingProfileKind.Absolute,
+                chargingSchedule = listOf(
+                    ChargingSchedule(
+                        id = 1,
+                        chargingRateUnit = ChargingRateUnit.A,
+                        chargingSchedulePeriod = listOf(
+                            ChargingSchedulePeriod(startPeriod = 0, limit = 16.789, numberPhases = 3),
+                            ChargingSchedulePeriod(startPeriod = 3600, limit = 10.456, numberPhases = 3)
+                        ),
+                        minChargingRate = 6.999
+                    )
+                )
+            )
+        )
+
+        messageSerializer.toPayloadString(request) shouldBe
+            """{"evseId":1,"chargingProfile":{"id":99,"stackLevel":0,"chargingProfilePurpose":"TxDefaultProfile","chargingProfileKind":"Absolute","chargingSchedule":[{"id":1,"chargingRateUnit":"A","chargingSchedulePeriod":[{"startPeriod":0,"limit":16.7,"numberPhases":3},{"startPeriod":3600,"limit":10.4,"numberPhases":3}],"minChargingRate":6.9}]}}"""
+    }
+})

--- a/v201/src/test/resources/smartcharging/get-composite-schedule-resp.json
+++ b/v201/src/test/resources/smartcharging/get-composite-schedule-resp.json
@@ -1,0 +1,25 @@
+[
+  3,
+  "c3d4e5f6-a7b8-9012-cdef-123456789012",
+  {
+    "status": "Accepted",
+    "schedule": {
+      "evseId": 1,
+      "duration": 3600,
+      "scheduleStart": "2025-05-22T08:29:27.000Z",
+      "chargingRateUnit": "A",
+      "chargingSchedulePeriod": [
+        {
+          "startPeriod": 0,
+          "limit": 32.123,
+          "numberPhases": 3
+        },
+        {
+          "startPeriod": 1800,
+          "limit": 20.567,
+          "numberPhases": 3
+        }
+      ]
+    }
+  }
+]

--- a/v201/src/test/resources/smartcharging/set-charging-profile-req.json
+++ b/v201/src/test/resources/smartcharging/set-charging-profile-req.json
@@ -1,0 +1,33 @@
+[
+  2,
+  "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "SetChargingProfile",
+  {
+    "evseId": 1,
+    "chargingProfile": {
+      "id": 99,
+      "stackLevel": 0,
+      "chargingProfilePurpose": "TxDefaultProfile",
+      "chargingProfileKind": "Absolute",
+      "chargingSchedule": [
+        {
+          "id": 1,
+          "chargingRateUnit": "A",
+          "chargingSchedulePeriod": [
+            {
+              "startPeriod": 0,
+              "limit": 16.789,
+              "numberPhases": 3
+            },
+            {
+              "startPeriod": 3600,
+              "limit": 10.456,
+              "numberPhases": 3
+            }
+          ],
+          "minChargingRate": 6.999
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
The OCPP spec requires charging rate values to have at most one digit fraction. Add a Jackson serializer/deserializer pair that floors Double values to 1 decimal place using BigDecimal.setScale, and annotate the limit and minChargingRate fields on the v16 and v201 wire types. Serialization and deserialization tests added for SetChargingProfile and GetCompositeSchedule in both protocol versions.
