### PR TITLE
chore: Renovate config - enable automerge on all renovate PRs [NOJIRA]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":semanticCommitTypeAll(chore)"
+    ":semanticCommitTypeAll(chore)",
+    ":automergeAll"
   ],
   "semanticCommits": "enabled",
   "prConcurrentLimit": 2,


### PR DESCRIPTION
## Summary
- Add `:automergeAll` to Renovate extends to enable automerge on all Renovate PRs

## Test plan
- [ ] Verify Renovate PRs are automerged after CI passes