### PR TITLE
chore(deps): migrate Jackson 2.x → 3.1.4 [NOJIRA]

### DIFF
--- a/core/src/main/kotlin/com/monta/library/ocpp/common/serialization/ChargingRateScaleSerializer.kt
+++ b/core/src/main/kotlin/com/monta/library/ocpp/common/serialization/ChargingRateScaleSerializer.kt
@@ -1,16 +1,16 @@
 package com.monta.library.ocpp.common.serialization
 
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import tools.jackson.core.JsonGenerator
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.SerializationContext
+import tools.jackson.databind.deser.std.StdDeserializer
+import tools.jackson.databind.ser.std.StdSerializer
 import java.math.BigDecimal
 import java.math.RoundingMode
 
 class OneDecimalFloorSerializer : StdSerializer<Double>(Double::class.java) {
-    override fun serialize(value: Double, gen: JsonGenerator, provider: SerializerProvider) {
+    override fun serialize(value: Double, gen: JsonGenerator, provider: SerializationContext) {
         gen.writeNumber(BigDecimal(value).setScale(1, RoundingMode.HALF_UP).toDouble())
     }
 }

--- a/core/src/main/kotlin/com/monta/library/ocpp/common/serialization/Message.kt
+++ b/core/src/main/kotlin/com/monta/library/ocpp/common/serialization/Message.kt
@@ -1,7 +1,7 @@
 package com.monta.library.ocpp.common.serialization
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.databind.JsonNode
+import tools.jackson.databind.JsonNode
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,

--- a/core/src/main/kotlin/com/monta/library/ocpp/common/serialization/MessageSerializer.kt
+++ b/core/src/main/kotlin/com/monta/library/ocpp/common/serialization/MessageSerializer.kt
@@ -1,17 +1,17 @@
 package com.monta.library.ocpp.common.serialization
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.monta.library.ocpp.common.error.OcppErrorResponder
 import org.slf4j.LoggerFactory
+import tools.jackson.core.JsonGenerator
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.SerializationContext
+import tools.jackson.databind.cfg.DateTimeFeature
+import tools.jackson.databind.module.SimpleModule
+import tools.jackson.databind.node.ObjectNode
+import tools.jackson.databind.ser.std.StdSerializer
+import tools.jackson.module.kotlin.jacksonMapperBuilder
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
@@ -33,9 +33,12 @@ class MessageSerializer(
         private val logger = LoggerFactory.getLogger(MessageSerializer::class.java)
     }
 
-    private val objectMapper = jacksonObjectMapper().apply {
-        registerModule(
-            JavaTimeModule().apply {
+    // Jackson 3 mappers are immutable and configured through the builder. java.time support is
+    // built into databind now, so we only register a SimpleModule for our custom ZonedDateTime
+    // serializers instead of the old JavaTimeModule.
+    private val objectMapper = jacksonMapperBuilder()
+        .addModule(
+            SimpleModule().apply {
                 // this is a bit of a flaky way to differentiate between 1.6 and 2.0.1 serialization.
                 // All 1.6 data classes use ZonedDateTime, 2.0.1 uses OffsetDateTime.
                 // Some 1.6 charge points do not accept high resolution timestamps so we just truncate to seconds.
@@ -51,11 +54,11 @@ class MessageSerializer(
                 }
             }
         )
-        setSerializationInclusion(JsonInclude.Include.NON_NULL)
-        findAndRegisterModules()
-        configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-    }
+        .changeDefaultPropertyInclusion { it.withValueInclusion(JsonInclude.Include.NON_NULL) }
+        .findAndAddModules()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .build()
 
     fun parseMessageId(json: String): Result<String> {
         return runCatching {
@@ -186,7 +189,7 @@ class MessageSerializer(
         override fun serialize(
             value: ZonedDateTime?,
             gen: JsonGenerator?,
-            provider: SerializerProvider?
+            ctxt: SerializationContext?
         ) {
             gen?.writeString(FORMAT.format(value))
         }
@@ -200,7 +203,7 @@ class MessageSerializer(
         override fun serialize(
             value: ZonedDateTime?,
             gen: JsonGenerator?,
-            provider: SerializerProvider?
+            ctxt: SerializationContext?
         ) {
             gen?.writeString(FORMAT.format(value))
         }

--- a/core/src/main/kotlin/com/monta/library/ocpp/common/serialization/Payloadable.kt
+++ b/core/src/main/kotlin/com/monta/library/ocpp/common/serialization/Payloadable.kt
@@ -1,6 +1,6 @@
 package com.monta.library.ocpp.common.serialization
 
-import com.fasterxml.jackson.databind.JsonNode
+import tools.jackson.databind.JsonNode
 
 /**
  * I made up a word *_*

--- a/core/src/test/kotlin/com/monta/library/ocpp/TestUtils.kt
+++ b/core/src/test/kotlin/com/monta/library/ocpp/TestUtils.kt
@@ -1,7 +1,7 @@
 package com.monta.library.ocpp
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.databind.JsonNode
+import tools.jackson.module.kotlin.jacksonObjectMapper
 
 object TestUtils {
     private val objectMapper = jacksonObjectMapper()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 javaToolChainVersion=25
-libraryVersion=2.0.0
+libraryVersion=3.0.0
 org.gradle.jvmargs=-Xmx4096m
 org.gradle.warning.mode=all

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.3.21"
 coroutines = "1.11.0"
-jackson = "2.21.3"
+jackson = "3.1.4"
 kotest = "6.1.11"
 strikt = "0.35.1"
 jupiter = "6.1.0"
@@ -21,12 +21,14 @@ coroutines-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8" }
 coroutines-slf4j = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j" }
 
 # Jackson
-jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
-jackson-core = { module = "com.fasterxml.jackson.core:jackson-core" }
+# NOTE: Jackson 3 moved core/databind/modules to the `tools.jackson` groups & packages.
+# Annotations intentionally stay on the 2.x `com.fasterxml.jackson` artifact (pinned by the BOM),
+# and java.time (jsr310) support is now built into databind, so the jsr310 module is gone.
+jackson-bom = { module = "tools.jackson:jackson-bom", version.ref = "jackson" }
+jackson-core = { module = "tools.jackson.core:jackson-core" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations" }
-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }
-jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin" }
-jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" }
+jackson-databind = { module = "tools.jackson.core:jackson-databind" }
+jackson-module-kotlin = { module = "tools.jackson.module:jackson-module-kotlin" }
 
 # Kotest / Testing
 kotest-bom = { module = "io.kotest:kotest-bom", version.ref = "kotest" }
@@ -42,7 +44,7 @@ logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "lo
 [bundles]
 kotlin = ["kotlin-stdlib-jdk8"]
 coroutines = ["coroutines-core", "coroutines-jdk8", "coroutines-slf4j"]
-jackson = ["jackson-core", "jackson-annotations", "jackson-databind", "jackson-module-kotlin", "jackson-datatype-jsr310"]
+jackson = ["jackson-core", "jackson-annotations", "jackson-databind", "jackson-module-kotlin"]
 kotest-test = ["kotest-runner-junit5", "kotest-assertions-core", "strikt-core", "junit-jupiter-params"]
 kotest-test-runtime = ["junit-jupiter-engine"]
 logback = ["logback-classic"]

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     // Serialization
     implementation("io.ktor:ktor-server-content-negotiation-jvm")
     implementation("io.ktor:ktor-client-content-negotiation")
-    implementation("io.ktor:ktor-serialization-jackson-jvm")
+    implementation("io.ktor:ktor-serialization-jackson3-jvm")
 
     // Jackson
     implementation(platform(libs.jackson.bom))

--- a/server/src/main/kotlin/com/monta/ocpp/MontaApplication.kt
+++ b/server/src/main/kotlin/com/monta/ocpp/MontaApplication.kt
@@ -19,7 +19,8 @@ import com.monta.library.ocpp.v201.blocks.provisioning.ProvisioningServerDispatc
 import com.monta.library.ocpp.v201.common.AuthorizationStatus
 import com.monta.library.ocpp.v201.common.IdTokenInfo
 import com.monta.library.ocpp.v201.server.OcppServerV201Builder
-import io.ktor.serialization.jackson3.*
+import io.ktor.serialization.jackson3.JacksonWebsocketContentConverter
+import io.ktor.serialization.jackson3.jackson
 import io.ktor.server.application.*
 import io.ktor.server.netty.*
 import io.ktor.server.plugins.calllogging.*

--- a/server/src/main/kotlin/com/monta/ocpp/MontaApplication.kt
+++ b/server/src/main/kotlin/com/monta/ocpp/MontaApplication.kt
@@ -19,7 +19,7 @@ import com.monta.library.ocpp.v201.blocks.provisioning.ProvisioningServerDispatc
 import com.monta.library.ocpp.v201.common.AuthorizationStatus
 import com.monta.library.ocpp.v201.common.IdTokenInfo
 import com.monta.library.ocpp.v201.server.OcppServerV201Builder
-import io.ktor.serialization.jackson.*
+import io.ktor.serialization.jackson3.*
 import io.ktor.server.application.*
 import io.ktor.server.netty.*
 import io.ktor.server.plugins.calllogging.*
@@ -57,7 +57,7 @@ fun Application.module() {
     // WebSockets
     install(WebSockets) {
         contentConverter = JacksonWebsocketContentConverter(
-            objectmapper = MontaSerialization.getDefaultMapper()
+            MontaSerialization.getDefaultMapper()
         )
 
         pingPeriod = Duration.ofSeconds(15).toKotlinDuration()

--- a/server/src/main/kotlin/com/monta/ocpp/MontaSerialization.kt
+++ b/server/src/main/kotlin/com/monta/ocpp/MontaSerialization.kt
@@ -1,11 +1,11 @@
 package com.monta.ocpp
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.cfg.DateTimeFeature
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
 
 object MontaSerialization {
 
@@ -13,27 +13,32 @@ object MontaSerialization {
         serializeNulls: Boolean = false
     ): ObjectMapper {
         return withDefaults(
-            objectMapper = ObjectMapper(),
+            builder = JsonMapper.builder(),
             serializeNulls = serializeNulls
-        )
+        ).build()
     }
 
+    /**
+     * Jackson 3 mappers are immutable, so configuration happens on the builder. java.time support is
+     * built into databind now (no JavaTimeModule needed); we only register the Kotlin module here.
+     */
     fun withDefaults(
-        objectMapper: ObjectMapper,
+        builder: JsonMapper.Builder,
         serializeNulls: Boolean = false
-    ): ObjectMapper {
-        objectMapper.registerKotlinModule()
-        objectMapper.registerModule(JavaTimeModule())
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        objectMapper.setSerializationInclusion(
-            if (serializeNulls) {
-                JsonInclude.Include.ALWAYS
-            } else {
-                JsonInclude.Include.NON_NULL
+    ): JsonMapper.Builder {
+        return builder
+            .addModule(kotlinModule())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .changeDefaultPropertyInclusion {
+                it.withValueInclusion(
+                    if (serializeNulls) {
+                        JsonInclude.Include.ALWAYS
+                    } else {
+                        JsonInclude.Include.NON_NULL
+                    }
+                )
             }
-        )
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-        objectMapper.findAndRegisterModules()
-        return objectMapper
+            .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .findAndAddModules()
     }
 }

--- a/v16/src/main/kotlin/com/monta/library/ocpp/v16/smartcharge/ChargingProfile.kt
+++ b/v16/src/main/kotlin/com/monta/library/ocpp/v16/smartcharge/ChargingProfile.kt
@@ -1,7 +1,5 @@
 package com.monta.library.ocpp.v16.smartcharge
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.monta.library.ocpp.common.chargingprofile.ChargingProfileKind
 import com.monta.library.ocpp.common.chargingprofile.ChargingRateUnit
 import com.monta.library.ocpp.common.chargingprofile.CommonChargingProfile
@@ -10,6 +8,8 @@ import com.monta.library.ocpp.common.chargingprofile.RecurrencyKind
 import com.monta.library.ocpp.common.serialization.OneDecimalFloorDeserializer
 import com.monta.library.ocpp.common.serialization.OneDecimalFloorSerializer
 import com.monta.library.ocpp.common.toZonedDateTime
+import tools.jackson.databind.annotation.JsonDeserialize
+import tools.jackson.databind.annotation.JsonSerialize
 import java.time.ZonedDateTime
 
 enum class ChargingProfilePurposeType {

--- a/v16/src/test/kotlin/com/monta/library/ocpp/TestUtils.kt
+++ b/v16/src/test/kotlin/com/monta/library/ocpp/TestUtils.kt
@@ -1,7 +1,7 @@
 package com.monta.library.ocpp
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.databind.JsonNode
+import tools.jackson.module.kotlin.jacksonObjectMapper
 
 object TestUtils {
     private val objectMapper = jacksonObjectMapper()

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/common/chargingprofile/ChargingSchedule.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/common/chargingprofile/ChargingSchedule.kt
@@ -1,13 +1,13 @@
 package com.monta.library.ocpp.v201.common.chargingprofile
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.monta.library.ocpp.common.chargingprofile.ChargingRateUnit
 import com.monta.library.ocpp.common.chargingprofile.CommonChargingProfile
 import com.monta.library.ocpp.common.serialization.OneDecimalFloorDeserializer
 import com.monta.library.ocpp.common.serialization.OneDecimalFloorSerializer
 import com.monta.library.ocpp.common.toZonedDateTime
 import com.monta.library.ocpp.v201.common.CustomData
+import tools.jackson.databind.annotation.JsonDeserialize
+import tools.jackson.databind.annotation.JsonSerialize
 import java.time.ZonedDateTime
 
 data class ChargingSchedule(

--- a/v201/src/main/kotlin/com/monta/library/ocpp/v201/common/chargingprofile/ChargingSchedulePeriod.kt
+++ b/v201/src/main/kotlin/com/monta/library/ocpp/v201/common/chargingprofile/ChargingSchedulePeriod.kt
@@ -1,11 +1,11 @@
 package com.monta.library.ocpp.v201.common.chargingprofile
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.monta.library.ocpp.common.chargingprofile.CommonChargingProfile
 import com.monta.library.ocpp.common.serialization.OneDecimalFloorDeserializer
 import com.monta.library.ocpp.common.serialization.OneDecimalFloorSerializer
 import com.monta.library.ocpp.v201.common.CustomData
+import tools.jackson.databind.annotation.JsonDeserialize
+import tools.jackson.databind.annotation.JsonSerialize
 
 data class ChargingSchedulePeriod(
     /**

--- a/v201/src/test/kotlin/com/monta/library/ocpp/TestUtils.kt
+++ b/v201/src/test/kotlin/com/monta/library/ocpp/TestUtils.kt
@@ -1,7 +1,7 @@
 package com.monta.library.ocpp
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.databind.JsonNode
+import tools.jackson.module.kotlin.jacksonObjectMapper
 
 object TestUtils {
     private val objectMapper = jacksonObjectMapper()


### PR DESCRIPTION
## Summary

Migrates the project from **Jackson 2.21.3 → 3.1.4**. Jackson was the only dependency in the version catalog with a pending **major** upgrade — every other entry (Kotlin, coroutines, Kotest, strikt, JUnit Jupiter, ktlint, kover) is already on its latest stable release.

Jackson 3 renames the core/databind/module artifacts and packages from `com.fasterxml.jackson` to `tools.jackson`, which is exactly what allows Jackson 2 and 3 to coexist (relevant for ktor in the `server` module).

## Changes

- **Version catalog** — repoint `jackson-bom`/`core`/`databind`/`module-kotlin` to the `tools.jackson` groups. `jackson-annotations` stays on `com.fasterxml.jackson` (the 3.x BOM intentionally pins annotations to 2.x). Removed `jackson-datatype-jsr310` — java.time support is now built into databind.
- **`MessageSerializer`** — mappers are immutable in Jackson 3, so it's now built via `jacksonMapperBuilder().build()`; custom `ZonedDateTime` serializers register through a `SimpleModule` instead of `JavaTimeModule`; `setSerializationInclusion` → `changeDefaultPropertyInclusion`; `SerializationFeature.WRITE_DATES_AS_TIMESTAMPS` → the new `DateTimeFeature`; `StdSerializer.serialize` now takes `SerializationContext` instead of `SerializerProvider`.
- **Databind annotations** (`@JsonSerialize`/`@JsonDeserialize`) in the v16/v201 charging-profile classes → `tools.jackson.databind.annotation`. Plain annotations (`@JsonTypeInfo`, `@JsonProperty`, `@JsonValue`, `@JsonIgnore`) are unchanged.
- **server** — swap `ktor-serialization-jackson` for `ktor-serialization-jackson3` (which pulls `tools.jackson`), and rewrite `MontaSerialization` against the `JsonMapper.Builder` API exposed by the jackson3 `jackson {}` DSL.

## ⚠️ Breaking change

This is breaking for consumers of the library — the public API now exposes Jackson 3 types (e.g. `Message.payload: tools.jackson.databind.JsonNode`). This likely warrants a major version bump (currently `2.0.0`). Renovate may also need a note so it doesn't try to track the abandoned `com.fasterxml.jackson` 2.x line.

## Verification

- All four modules compile.
- **130 tests pass** (core 12, v16 110, v201 8), zero failures.
- ktlint and kover verification clean.